### PR TITLE
Differentiate between empty and no mutations

### DIFF
--- a/src/ExecuteQueryHandler.js
+++ b/src/ExecuteQueryHandler.js
@@ -21,8 +21,11 @@ export default class ExecuteQueryHandler {
     if (!queryEngine)
       throw new Error(`${pathData} has no queryEngine setting`);
     const query = await path.sparql;
-    if (!query)
+    if (query === null || query === undefined)
       throw new Error(`${pathData} has no sparql property`);
+    // No results if the query is empty
+    if (query.length === 0)
+      return;
 
     // Extract the term from every query result
     for await (const bindings of queryEngine.execute(query))

--- a/src/MutationFunctionHandler.js
+++ b/src/MutationFunctionHandler.js
@@ -45,9 +45,9 @@ export default class MutationFunctionHandler {
     const mutationType = this._mutationType;
     if (!objects)
       return [{ mutationType, conditions }];
-    // If no objects are affected, do not perform any mutations
+    // No need to continue if there are no objects to mutate
     if (objects.length === 0)
-      return [];
+      return [{ objects: [] }];
 
     // Otherwise, mutate the affected objects
     const { predicate } = conditions.pop();

--- a/src/SparqlHandler.js
+++ b/src/SparqlHandler.js
@@ -18,7 +18,8 @@ export default class SparqlHandler {
     // First check if we have a mutation expression
     const mutationExpressions = await path.mutationExpressions;
     if (Array.isArray(mutationExpressions) && mutationExpressions.length)
-      return mutationExpressions.map(e => this.mutationExpressionToQuery(e)).join('\n;\n');
+      // Remove empty results to prevent dangling semicolons
+      return mutationExpressions.map(e => this.mutationExpressionToQuery(e)).filter(Boolean).join('\n;\n');
 
     // Otherwise, fall back to checking for a path expression
     const pathExpression = await path.pathExpression;
@@ -50,6 +51,9 @@ export default class SparqlHandler {
   }
 
   mutationExpressionToQuery({ mutationType, conditions, predicate, objects }) {
+    // If there are no objects to mutate there is no query
+    if (objects && objects.length === 0)
+      return '';
     // If the only condition is a subject, we need no WHERE clause
     const scope = {};
     let subject, where;

--- a/test/unit/ExecuteQueryHandler-test.js
+++ b/test/unit/ExecuteQueryHandler-test.js
@@ -40,4 +40,11 @@ describe('a ExecuteQueryHandler instance', () => {
       items.push(result);
     expect(items).toEqual(cache);
   });
+
+  it('immediately returns if there is an empty query', async () => {
+    const pathData = { settings: { queryEngine: { execute: () => [new Map([['?a', 'b']])] } }, toString: () => 'path' };
+    const iterable = handler.handle(pathData, { sparql: '' });
+    const iterator = iterable[Symbol.asyncIterator]();
+    await expect((await iterator.next()).value).toEqual(undefined);
+  });
 });

--- a/test/unit/MutationFunctionHandler-test.js
+++ b/test/unit/MutationFunctionHandler-test.js
@@ -297,7 +297,7 @@ describe('a MutationFunctionHandler instance not allowing 0 args', () => {
       ];
 
       expect(await handler.createMutationExpressions(pathData, { pathExpression }, args))
-        .toEqual([]);
+        .toEqual([{ objects: [] }]);
     });
   });
 

--- a/test/unit/SparqlHandler-test.js
+++ b/test/unit/SparqlHandler-test.js
@@ -346,6 +346,11 @@ describe('a SparqlHandler instance', () => {
           }`));
       });
     });
+
+    it('returns an empty query if there are no applicable objects', async () => {
+      const mutationExpressions = [{ objects: [] }];
+      expect(await handler.handle({}, { mutationExpressions })).toEqual('');
+    });
   });
 
   describe('#createVar', () => {


### PR DESCRIPTION
This solves query-ldflex executing 2 select queries when there is nothing to delete.

This way there is a difference between a proxy chain having no mutations (mutationExpressions returns an empty array) and having a mutation that doesn't apply to any objects (array contains a mutation with no objects).

This is also required to make sure objects as function parameters for mutations work with the query-ldflex library.