### PR TITLE
Support object maps as parameters for mutations

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,7 +24,7 @@
     no-console: [ error, { allow: [ warn ] } ],
     no-case-declarations: off,
     no-div-regex: error,
-    no-else-return: error,
+    no-else-return: off,
     no-empty-function: error,
     no-empty-pattern: error,
     no-eq-null: error,

--- a/src/MutationFunctionHandler.js
+++ b/src/MutationFunctionHandler.js
@@ -32,28 +32,62 @@ export default class MutationFunctionHandler {
   }
 
   async createMutationExpressions(pathData, path, args) {
-    // Check if we have a valid path
+    // The arguments are the affected objects
+    // Do this first since an object input can change the conditions
+    let objects;
+    if (args.length === 1 && this.isObject(args[0])) {
+      objects = Object.keys(args[0]).map(key => {
+        let values = args[0][key];
+        // Simulate the function being called with no arguments
+        if (values === null || values === undefined)
+          values = [];
+        // Shortcut for single arguments
+        else if (!Array.isArray(values))
+          values = [values];
+        // Currently the path value is only used by the SolidDeleteFunctionHandlers in query-ldflex
+        // and needs to be updated to be the correct path there.
+        // pathData still matches the old path though.
+        return { key, value: this.extractObjects(pathData, path[key], values) };
+      });
+    }
+    else {
+      objects = await this.extractObjects(pathData, path, args);
+    }
+    // If no objects were specified, mutate all objects in the domain
+    const mutationType = this._mutationType;
+    if (!objects)
+      return [{ mutationType, conditions: await path.pathExpression }];
+    // No need to continue if there are no objects to mutate
+    if (objects.length === 0)
+      return [{ objects: [] }];
+
+    // Check if the input was an object map
+    const hasObjects = !objects[0].termType;
+
+    if (hasObjects) {
+      // Make sure promise structure is the same as when there are no objects
+      return Promise.all(objects.map(async obj => {
+        const conditions = await path[obj.key].pathExpression;
+        return this.createMutationExpression(pathData, conditions, await obj.value);
+      }));
+    }
+
     const conditions = await path.pathExpression;
+    return [this.createMutationExpression(pathData, conditions, objects)];
+  }
+
+  createMutationExpression(pathData, conditions, objects) {
+    // Check if we have a valid path
     if (!Array.isArray(conditions))
       throw new Error(`${pathData} has no pathExpression property`);
     if (conditions.length < 2)
       throw new Error(`${pathData} should at least contain a subject and a predicate`);
 
-    // The arguments are the affected objects
-    const objects = await this.extractObjects(pathData, path, args);
-    // If no objects were specified, mutate all objects in the domain
-    const mutationType = this._mutationType;
-    if (!objects)
-      return [{ mutationType, conditions }];
-    // No need to continue if there are no objects to mutate
-    if (objects.length === 0)
-      return [{ objects: [] }];
-
-    // Otherwise, mutate the affected objects
-    const { predicate } = conditions.pop();
+    // Otherwise, use the previous predicate
+    const { predicate } = conditions[conditions.length - 1];
     if (!predicate)
       throw new Error(`Expected predicate in ${pathData}`);
-    return [{ mutationType, conditions, predicate, objects }];
+    return { mutationType: this._mutationType, conditions: conditions.slice(0, conditions.length - 1), predicate, objects };
   }
 
   async extractObjects(pathData, path, args) {
@@ -75,6 +109,18 @@ export default class MutationFunctionHandler {
       }
     }
     return objects;
+  }
+
+  isObject(arg) {
+    if (!arg)
+      return false;
+    if (typeof arg === 'string')
+      return false;
+    if (arg.termType)
+      return false;
+    if (arg[Symbol.asyncIterator])
+      return false;
+    return true;
   }
 
   extractObject(pathData, path, arg) {

--- a/src/SetFunctionHandler.js
+++ b/src/SetFunctionHandler.js
@@ -11,16 +11,14 @@ import MutationFunctionHandler from './MutationFunctionHandler';
 export default class SetFunctionHandler extends MutationFunctionHandler {
   handle(pathData, path) {
     return (...args) => {
-      // Don't support object maps with multiple arguments
-      if (args.length !== 1 || !this.isObject(args[0])) {
-        if (args.some(arg => this.isObject(arg)))
-          throw new Error('Object maps can only appear as a single argument');
-        return path.delete().add(...args);
-      }
-
-      // Still have to make sure the deletes happen before the adds
-      const deletePath = Object.keys(args[0]).reduce((newPath, key) => newPath.delete({ [key]: [] }), path);
-
+      // First, delete all existing values for the property/properties
+      const deletePath = !this.hasPropertyMap(args) ?
+        // When a single property is given, delete all of its values
+        path.delete() :
+        // When a map of properties is given, delete all of their values
+        Object.keys(args[0]).reduce((previousPath, property) =>
+          previousPath.delete({ [property]: [] }), path);
+      // Next, insert the new values
       return deletePath.add(...args);
     };
   }

--- a/src/SetFunctionHandler.js
+++ b/src/SetFunctionHandler.js
@@ -1,3 +1,5 @@
+import MutationFunctionHandler from './MutationFunctionHandler';
+
 /**
  * Returns a function that deletes all existing values
  * for the path, and then adds the given values to the path.
@@ -6,8 +8,20 @@
  * - a delete function on the path proxy.
  * - an add function on the path proxy.
  */
-export default class SetFunctionHandler {
+export default class SetFunctionHandler extends MutationFunctionHandler {
   handle(pathData, path) {
-    return (...args) => path.delete().add(...args);
+    return (...args) => {
+      // Don't support object maps with multiple arguments
+      if (args.length !== 1 || !this.isObject(args[0])) {
+        if (args.some(arg => this.isObject(arg)))
+          throw new Error('Object maps can only appear as a single argument');
+        return path.delete().add(...args);
+      }
+
+      // Still have to make sure the deletes happen before the adds
+      const deletePath = Object.keys(args[0]).reduce((newPath, key) => newPath.delete({ [key]: [] }), path);
+
+      return deletePath.add(...args);
+    };
   }
 }

--- a/test/integration/mutation-expressions-test.js
+++ b/test/integration/mutation-expressions-test.js
@@ -140,4 +140,46 @@ describe('a query path with a path expression handler', () => {
       },
     ]);
   });
+
+  it('resolves a path with a deletion of 2 links, an addition on a link, a link and another addition on a link using object maps', async () => {
+    const path = await person
+      .delete({ friends: person.friends, firstName: 'ruben' })
+      .add({ firstName: 'Ruben' })
+      .friends.add({ firstName: 'Ruben' }).mutationExpressions;
+    expect(path).toEqual([
+      {
+        mutationType: 'DELETE',
+        conditions: [
+          { subject },
+        ],
+        predicate: namedNode('http://xmlns.com/foaf/0.1/knows'),
+        objects: [namedNode('http://ex.org/#1'), namedNode('http://ex.org/#2')],
+      },
+      {
+        mutationType: 'DELETE',
+        conditions: [
+          { subject },
+        ],
+        predicate: namedNode('http://xmlns.com/foaf/0.1/givenName'),
+        objects: [literal('ruben')],
+      },
+      {
+        mutationType: 'INSERT',
+        conditions: [
+          { subject },
+        ],
+        predicate: namedNode('http://xmlns.com/foaf/0.1/givenName'),
+        objects: [literal('Ruben')],
+      },
+      {
+        mutationType: 'INSERT',
+        conditions: [
+          { subject },
+          { predicate: namedNode('http://xmlns.com/foaf/0.1/knows') },
+        ],
+        predicate: namedNode('http://xmlns.com/foaf/0.1/givenName'),
+        objects: [literal('Ruben')],
+      },
+    ]);
+  });
 });

--- a/test/integration/mutation-expressions-test.js
+++ b/test/integration/mutation-expressions-test.js
@@ -43,8 +43,10 @@ describe('a query path with a path expression handler', () => {
           { subject },
           { predicate: namedNode('http://xmlns.com/foaf/0.1/knows') },
         ],
-        predicate: namedNode('http://xmlns.com/foaf/0.1/givenName'),
-        objects: [literal('Ruben')],
+        predicateObjects: [{
+          predicate: namedNode('http://xmlns.com/foaf/0.1/givenName'),
+          objects: [literal('Ruben')],
+        }],
       },
     ]);
   });
@@ -58,8 +60,10 @@ describe('a query path with a path expression handler', () => {
           { subject },
           { predicate: namedNode('http://xmlns.com/foaf/0.1/knows') },
         ],
-        predicate: namedNode('http://xmlns.com/foaf/0.1/givenName'),
-        objects: [namedNode('http://ex.org/#1'), namedNode('http://ex.org/#2')],
+        predicateObjects: [{
+          predicate: namedNode('http://xmlns.com/foaf/0.1/givenName'),
+          objects: [namedNode('http://ex.org/#1'), namedNode('http://ex.org/#2')],
+        }],
       },
     ]);
   });
@@ -73,8 +77,10 @@ describe('a query path with a path expression handler', () => {
           { subject },
           { predicate: namedNode('http://xmlns.com/foaf/0.1/knows') },
         ],
-        predicate: namedNode('http://xmlns.com/foaf/0.1/givenName'),
-        objects: [literal('Ruben'), namedNode('http://ex.org/#1'), namedNode('http://ex.org/#2')],
+        predicateObjects: [{
+          predicate: namedNode('http://xmlns.com/foaf/0.1/givenName'),
+          objects: [literal('Ruben'), namedNode('http://ex.org/#1'), namedNode('http://ex.org/#2')],
+        }],
       },
     ]);
   });
@@ -88,8 +94,10 @@ describe('a query path with a path expression handler', () => {
           { subject },
           { predicate: namedNode('http://xmlns.com/foaf/0.1/knows') },
         ],
-        predicate: namedNode('http://xmlns.com/foaf/0.1/givenName'),
-        objects: [literal('Ruben'), namedNode('http://ex.org/#1'), namedNode('http://ex.org/#2')],
+        predicateObjects: [{
+          predicate: namedNode('http://xmlns.com/foaf/0.1/givenName'),
+          objects: [literal('Ruben'), namedNode('http://ex.org/#1'), namedNode('http://ex.org/#2')],
+        }],
       },
     ]);
   });
@@ -103,8 +111,10 @@ describe('a query path with a path expression handler', () => {
           { subject },
           { predicate: namedNode('http://xmlns.com/foaf/0.1/knows') },
         ],
-        predicate: namedNode('http://xmlns.com/foaf/0.1/givenName'),
-        objects: [literal('ruben')],
+        predicateObjects: [{
+          predicate: namedNode('http://xmlns.com/foaf/0.1/givenName'),
+          objects: [literal('ruben')],
+        }],
       },
       {
         mutationType: 'INSERT',
@@ -112,8 +122,10 @@ describe('a query path with a path expression handler', () => {
           { subject },
           { predicate: namedNode('http://xmlns.com/foaf/0.1/knows') },
         ],
-        predicate: namedNode('http://xmlns.com/foaf/0.1/givenName'),
-        objects: [literal('Ruben')],
+        predicateObjects: [{
+          predicate: namedNode('http://xmlns.com/foaf/0.1/givenName'),
+          objects: [literal('Ruben')],
+        }],
       },
     ]);
   });
@@ -126,8 +138,10 @@ describe('a query path with a path expression handler', () => {
         conditions: [
           { subject },
         ],
-        predicate: namedNode('http://xmlns.com/foaf/0.1/knows'),
-        objects: [namedNode('http://ex.org/#1'), namedNode('http://ex.org/#2')],
+        predicateObjects: [{
+          predicate: namedNode('http://xmlns.com/foaf/0.1/knows'),
+          objects: [namedNode('http://ex.org/#1'), namedNode('http://ex.org/#2')],
+        }],
       },
       {
         mutationType: 'INSERT',
@@ -135,8 +149,10 @@ describe('a query path with a path expression handler', () => {
           { subject },
           { predicate: namedNode('http://xmlns.com/foaf/0.1/knows') },
         ],
-        predicate: namedNode('http://xmlns.com/foaf/0.1/givenName'),
-        objects: [literal('Ruben')],
+        predicateObjects: [{
+          predicate: namedNode('http://xmlns.com/foaf/0.1/givenName'),
+          objects: [literal('Ruben')],
+        }],
       },
     ]);
   });
@@ -152,24 +168,26 @@ describe('a query path with a path expression handler', () => {
         conditions: [
           { subject },
         ],
-        predicate: namedNode('http://xmlns.com/foaf/0.1/knows'),
-        objects: [namedNode('http://ex.org/#1'), namedNode('http://ex.org/#2')],
-      },
-      {
-        mutationType: 'DELETE',
-        conditions: [
-          { subject },
+        predicateObjects: [
+          {
+            predicate: namedNode('http://xmlns.com/foaf/0.1/knows'),
+            objects: [namedNode('http://ex.org/#1'), namedNode('http://ex.org/#2')],
+          },
+          {
+            predicate: namedNode('http://xmlns.com/foaf/0.1/givenName'),
+            objects: [literal('ruben')],
+          },
         ],
-        predicate: namedNode('http://xmlns.com/foaf/0.1/givenName'),
-        objects: [literal('ruben')],
       },
       {
         mutationType: 'INSERT',
         conditions: [
           { subject },
         ],
-        predicate: namedNode('http://xmlns.com/foaf/0.1/givenName'),
-        objects: [literal('Ruben')],
+        predicateObjects: [{
+          predicate: namedNode('http://xmlns.com/foaf/0.1/givenName'),
+          objects: [literal('Ruben')],
+        }],
       },
       {
         mutationType: 'INSERT',
@@ -177,8 +195,10 @@ describe('a query path with a path expression handler', () => {
           { subject },
           { predicate: namedNode('http://xmlns.com/foaf/0.1/knows') },
         ],
-        predicate: namedNode('http://xmlns.com/foaf/0.1/givenName'),
-        objects: [literal('Ruben')],
+        predicateObjects: [{
+          predicate: namedNode('http://xmlns.com/foaf/0.1/givenName'),
+          objects: [literal('Ruben')],
+        }],
       },
     ]);
   });

--- a/test/unit/MutationFunctionHandler-test.js
+++ b/test/unit/MutationFunctionHandler-test.js
@@ -399,6 +399,15 @@ describe('a MutationFunctionHandler instance not allowing 0 args', () => {
       { subject: namedNode('https://example.org/#me') },
     ];
 
+    it('ignores empty objects', async () => {
+      const args = [{}];
+      const path = { pathExpression };
+
+      expect(await handler.createMutationExpressions(pathData, path, args)).toEqual([
+        { predicateObjects: [] },
+      ]);
+    });
+
     it('resolves a path of length 1', async () => {
       const args = [{ 'http://a': 'b', 'http://c': 'd' }];
       const path = { pathExpression };

--- a/test/unit/MutationFunctionHandler-test.js
+++ b/test/unit/MutationFunctionHandler-test.js
@@ -373,6 +373,44 @@ describe('a MutationFunctionHandler instance not allowing 0 args', () => {
       ]);
     });
   });
+
+  describe('with an object map arg', () => {
+    const pathExpression = [
+      { subject: namedNode('https://example.org/#me') },
+    ];
+
+    it('resolves a path of length 1', async () => {
+      const args = [{ 'http://a': 'b', 'http://c': 'd' }];
+      const path = { pathExpression };
+      path['http://a'] = { pathExpression: pathExpression.concat([{ predicate: namedNode('http://a') }]) };
+      path['http://c'] = { pathExpression: pathExpression.concat([{ predicate: namedNode('http://c') }]) };
+
+      expect(await handler.createMutationExpressions(pathData, path, args)).toEqual([
+        {
+          mutationType,
+          conditions: [{ subject: namedNode('https://example.org/#me') }],
+          predicate: namedNode('http://a'),
+          objects: [literal('b')],
+        },
+        {
+          mutationType,
+          conditions: [{ subject: namedNode('https://example.org/#me') }],
+          predicate: namedNode('http://c'),
+          objects: [literal('d')],
+        },
+      ]);
+    });
+
+    it('interprets no value as an empty argument list', async () => {
+      const args0 = [{ 'http://a': null }];
+      const args1 = [{ 'http://a': [] }];
+      const path = { pathExpression };
+      path['http://a'] = { pathExpression: pathExpression.concat([{ predicate: namedNode('http://a') }]) };
+
+      expect(await handler.createMutationExpressions(pathData, path, args0))
+        .toEqual(await handler.createMutationExpressions(pathData, path, args1));
+    });
+  });
 });
 
 describe('a MutationFunctionHandler instance allowing 0 args', () => {

--- a/test/unit/MutationFunctionHandler-test.js
+++ b/test/unit/MutationFunctionHandler-test.js
@@ -44,8 +44,10 @@ describe('a MutationFunctionHandler instance not allowing 0 args', () => {
           {
             mutationType,
             conditions: [{ subject: namedNode('https://example.org/#me') }],
-            predicate: namedNode('https://ex.org/p1'),
-            objects: [literal('Ruben')],
+            predicateObjects: [{
+              predicate: namedNode('https://ex.org/p1'),
+              objects: [literal('Ruben')],
+            }],
           },
         ]);
       });
@@ -72,8 +74,10 @@ describe('a MutationFunctionHandler instance not allowing 0 args', () => {
           {
             mutationType,
             conditions: [{ subject: namedNode('https://example.org/#me') }],
-            predicate: namedNode('https://ex.org/p1'),
-            objects: [namedNode('http://example.org/')],
+            predicateObjects: [{
+              predicate: namedNode('https://ex.org/p1'),
+              objects: [namedNode('http://example.org/')],
+            }],
           },
         ]);
       });
@@ -129,8 +133,10 @@ describe('a MutationFunctionHandler instance not allowing 0 args', () => {
           {
             mutationType,
             conditions: [{ subject: namedNode('https://example.org/#me') }],
-            predicate: namedNode('https://ex.org/p1'),
-            objects: [literal('other')],
+            predicateObjects: [{
+              predicate: namedNode('https://ex.org/p1'),
+              objects: [literal('other')],
+            }],
           },
         ]);
       });
@@ -149,8 +155,10 @@ describe('a MutationFunctionHandler instance not allowing 0 args', () => {
               { subject: namedNode('https://example.org/#me') },
               { predicate: namedNode('https://ex.org/p1') },
             ],
-            predicate: namedNode('https://ex.org/p2'),
-            objects: [literal('other')],
+            predicateObjects: [{
+              predicate: namedNode('https://ex.org/p2'),
+              objects: [literal('other')],
+            }],
           },
         ]);
       });
@@ -193,8 +201,10 @@ describe('a MutationFunctionHandler instance not allowing 0 args', () => {
           {
             mutationType,
             conditions: [{ subject: namedNode('https://example.org/#me') }],
-            predicate: namedNode('https://ex.org/p1'),
-            objects: [namedNode('http://example.org/other')],
+            predicateObjects: [{
+              predicate: namedNode('https://ex.org/p1'),
+              objects: [namedNode('http://example.org/other')],
+            }],
           },
         ]);
       });
@@ -213,8 +223,10 @@ describe('a MutationFunctionHandler instance not allowing 0 args', () => {
               { subject: namedNode('https://example.org/#me') },
               { predicate: namedNode('https://ex.org/p1') },
             ],
-            predicate: namedNode('https://ex.org/p2'),
-            objects: [namedNode('http://example.org/other')],
+            predicateObjects: [{
+              predicate: namedNode('https://ex.org/p2'),
+              objects: [namedNode('http://example.org/other')],
+            }],
           },
         ]);
       });
@@ -258,8 +270,10 @@ describe('a MutationFunctionHandler instance not allowing 0 args', () => {
         {
           mutationType,
           conditions: [{ subject: namedNode('https://example.org/#me') }],
-          predicate: namedNode('https://ex.org/p1'),
-          objects: [literal('other1'), literal('other2')],
+          predicateObjects: [{
+            predicate: namedNode('https://ex.org/p1'),
+            objects: [literal('other1'), literal('other2')],
+          }],
         },
       ]);
     });
@@ -278,8 +292,10 @@ describe('a MutationFunctionHandler instance not allowing 0 args', () => {
             { subject: namedNode('https://example.org/#me') },
             { predicate: namedNode('https://ex.org/p1') },
           ],
-          predicate: namedNode('https://ex.org/p2'),
-          objects: [literal('other1'), literal('other2')],
+          predicateObjects: [{
+            predicate: namedNode('https://ex.org/p2'),
+            objects: [literal('other1'), literal('other2')],
+          }],
         },
       ]);
     });
@@ -297,7 +313,7 @@ describe('a MutationFunctionHandler instance not allowing 0 args', () => {
       ];
 
       expect(await handler.createMutationExpressions(pathData, { pathExpression }, args))
-        .toEqual([{ objects: [] }]);
+        .toEqual([{ predicateObjects: [] }]);
     });
   });
 
@@ -319,8 +335,10 @@ describe('a MutationFunctionHandler instance not allowing 0 args', () => {
         {
           mutationType,
           conditions: [{ subject: namedNode('https://example.org/#me') }],
-          predicate: namedNode('https://ex.org/p1'),
-          objects: [literal('other1'), literal('other2')],
+          predicateObjects: [{
+            predicate: namedNode('https://ex.org/p1'),
+            objects: [literal('other1'), literal('other2')],
+          }],
         },
       ]);
     });
@@ -364,11 +382,13 @@ describe('a MutationFunctionHandler instance not allowing 0 args', () => {
         {
           mutationType,
           conditions: [{ subject: namedNode('https://example.org/#me') }],
-          predicate: namedNode('https://ex.org/p1'),
-          objects: [
-            literal('other1'), literal('other2'), literal('other3'),
-            literal('other4'), literal('other5'), literal('other6'),
-          ],
+          predicateObjects: [{
+            predicate: namedNode('https://ex.org/p1'),
+            objects: [
+              literal('other1'), literal('other2'), literal('other3'),
+              literal('other4'), literal('other5'), literal('other6'),
+            ],
+          }],
         },
       ]);
     });
@@ -389,14 +409,10 @@ describe('a MutationFunctionHandler instance not allowing 0 args', () => {
         {
           mutationType,
           conditions: [{ subject: namedNode('https://example.org/#me') }],
-          predicate: namedNode('http://a'),
-          objects: [literal('b')],
-        },
-        {
-          mutationType,
-          conditions: [{ subject: namedNode('https://example.org/#me') }],
-          predicate: namedNode('http://c'),
-          objects: [literal('d')],
+          predicateObjects: [
+            { predicate: namedNode('http://a'), objects: [literal('b')] },
+            { predicate: namedNode('http://c'), objects: [literal('d')] },
+          ],
         },
       ]);
     });

--- a/test/unit/SetFunctionHandler-test.js
+++ b/test/unit/SetFunctionHandler-test.js
@@ -41,5 +41,27 @@ describe('a SetFunctionHandler instance', () => {
         expect(functionResult).toEqual({ ...proxy, extended: true });
       });
     });
+
+    describe('with a map as function parameter', () => {
+      it('errors if there is more than 1 argument', () => {
+        expect(() => result({ a: 'b' }, 'c')).toThrowError();
+      });
+
+      it('executes a delete for every key', () => {
+        result({ a: 'b', c: 'd' });
+        expect(proxy.delete).toBeCalledTimes(2);
+        const args0 = proxy.delete.mock.calls[0];
+        const args1 = proxy.delete.mock.calls[1];
+        expect(args0).toEqual([{ a: [] }]);
+        expect(args1).toEqual([{ c: [] }]);
+      });
+
+      it('executes an add with the original arguments', () => {
+        result({ a: 'b', c: 'd' });
+        expect(proxy.add).toBeCalledTimes(1);
+        const args = proxy.add.mock.calls[0];
+        expect(args).toEqual([{ a: 'b', c: 'd' }]);
+      });
+    });
   });
 });

--- a/test/unit/SetFunctionHandler-test.js
+++ b/test/unit/SetFunctionHandler-test.js
@@ -44,7 +44,8 @@ describe('a SetFunctionHandler instance', () => {
 
     describe('with a map as function parameter', () => {
       it('errors if there is more than 1 argument', () => {
-        expect(() => result({ a: 'b' }, 'c')).toThrowError();
+        expect(() => result({ a: 'b' }, 'c'))
+          .toThrowError('Expected only a property map, but got 2 arguments');
       });
 
       it('executes a delete for every key', () => {

--- a/test/unit/SparqlHandler-test.js
+++ b/test/unit/SparqlHandler-test.js
@@ -178,8 +178,10 @@ describe('a SparqlHandler instance', () => {
           {
             mutationType: 'INSERT',
             conditions: [{ subject: namedNode('https://example.org/#D0') }],
-            predicate: namedNode('https://example.org/p'),
-            objects: [namedNode('https://example.org/#R0')],
+            predicateObjects: [{
+              predicate: namedNode('https://example.org/p'),
+              objects: [namedNode('https://example.org/#R0')],
+            }],
           },
         ];
 
@@ -194,8 +196,10 @@ describe('a SparqlHandler instance', () => {
           {
             mutationType: 'INSERT',
             conditions: [{ subject: namedNode('https://example.org/#D0') }],
-            predicate: namedNode('https://example.org/p'),
-            objects: [literal('Ruben')],
+            predicateObjects: [{
+              predicate: namedNode('https://example.org/p'),
+              objects: [literal('Ruben')],
+            }],
           },
         ];
 
@@ -210,12 +214,14 @@ describe('a SparqlHandler instance', () => {
           {
             mutationType: 'INSERT',
             conditions: [{ subject: namedNode('https://example.org/#D0') }],
-            predicate: namedNode('https://example.org/p'),
-            objects: [
-              namedNode('https://example.org/#R0'),
-              literal('Ruben'),
-              literal('Other'),
-            ],
+            predicateObjects: [{
+              predicate: namedNode('https://example.org/p'),
+              objects: [
+                namedNode('https://example.org/#R0'),
+                literal('Ruben'),
+                literal('Other'),
+              ],
+            }],
           },
         ];
 
@@ -234,8 +240,10 @@ describe('a SparqlHandler instance', () => {
               { predicate: namedNode('https://example.org/#Dp1') },
               { predicate: namedNode('https://example.org/#Dp2') },
             ],
-            predicate: namedNode('https://example.org/p'),
-            objects: [namedNode('https://example.org/#R0')],
+            predicateObjects: [{
+              predicate: namedNode('https://example.org/p'),
+              objects: [namedNode('https://example.org/#R0')],
+            }],
           },
         ];
 
@@ -256,8 +264,10 @@ describe('a SparqlHandler instance', () => {
               { subject: namedNode('https://example.org/#D0') },
               { predicate: namedNode('https://example.org/#') },
             ],
-            predicate: namedNode('https://example.org/p'),
-            objects: [namedNode('https://example.org/#R0')],
+            predicateObjects: [{
+              predicate: namedNode('https://example.org/p'),
+              objects: [namedNode('https://example.org/#R0')],
+            }],
           },
         ];
 
@@ -276,8 +286,10 @@ describe('a SparqlHandler instance', () => {
           {
             mutationType: 'INSERT',
             conditions: [{ subject: namedNode('https://example.org/#D0') }],
-            predicate: namedNode('https://example.org/p'),
-            objects: [literal('a"b')],
+            predicateObjects: [{
+              predicate: namedNode('https://example.org/p'),
+              objects: [literal('a"b')],
+            }],
           },
         ];
 
@@ -294,8 +306,10 @@ describe('a SparqlHandler instance', () => {
           {
             mutationType: 'DELETE',
             conditions: [{ subject: namedNode('https://example.org/#D0') }],
-            predicate: namedNode('https://example.org/p'),
-            objects: [namedNode('https://example.org/#R0')],
+            predicateObjects: [{
+              predicate: namedNode('https://example.org/p'),
+              objects: [namedNode('https://example.org/#R0')],
+            }],
           },
         ];
 
@@ -311,12 +325,14 @@ describe('a SparqlHandler instance', () => {
         {
           mutationType: 'DELETE',
           conditions: [{ subject: namedNode('https://example.org/#D0') }],
-          predicate: namedNode('https://example.org/p'),
-          objects: [
-            namedNode('https://example.org/#R0'),
-            literal('Ruben'),
-            literal('Other'),
-          ],
+          predicateObjects: [{
+            predicate: namedNode('https://example.org/p'),
+            objects: [
+              namedNode('https://example.org/#R0'),
+              literal('Ruben'),
+              literal('Other'),
+            ],
+          }],
         },
       ];
 
@@ -348,7 +364,7 @@ describe('a SparqlHandler instance', () => {
     });
 
     it('returns an empty query if there are no applicable objects', async () => {
-      const mutationExpressions = [{ objects: [] }];
+      const mutationExpressions = [{ predicateObjects: [] }];
       expect(await handler.handle({}, { mutationExpressions })).toEqual('');
     });
   });


### PR DESCRIPTION
This handles the first bullet point of #52. The value of the key/value pairs are interpreted as the args for a normal mutation call. So `.delete({ friends: [ 'a', 'b' ] })` is identical to `.friends.delete('a', 'b')`. As a shorthand method singular values don't have to be in an array. Also, null can be used instead of an empty array to indicate no arguments.