### PR TITLE
 Support @reverse predicates

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -143,7 +143,7 @@
     max-len: off,
     max-lines: off,
     max-nested-callbacks: error,
-    max-params: error,
+    max-params: [ error, { max: 5 } ],
     max-statements: off,
     max-statements-per-line: error,
     multiline-comment-style: [ error, separate-lines ],

--- a/src/JSONLDResolver.js
+++ b/src/JSONLDResolver.js
@@ -28,7 +28,8 @@ export default class JSONLDResolver {
    */
   resolve(property, pathData) {
     const predicate = lazyThenable(() => this.expandProperty(property));
-    const reverse = lazyThenable(() => this._context.then(context => context[property] && context[property]['@reverse']));
+    const reverse = lazyThenable(() => this._context.then(context =>
+      context[property] && context[property]['@reverse']));
     const resultsCache = this.getResultsCache(pathData, predicate, reverse);
     return pathData.extendPath({ property, predicate, resultsCache, reverse });
   }
@@ -63,11 +64,10 @@ export default class JSONLDResolver {
    */
   getResultsCache(pathData, predicate, reverse) {
     let { propertyCache } = pathData;
-    // Preloading does not work with reversed predicates
     return propertyCache && lazyThenable(async () => {
-      reverse = await reverse;
-      propertyCache = await propertyCache;
-      return !reverse && propertyCache && propertyCache[(await predicate).value];
+      // Preloading does not work with reversed predicates
+      propertyCache = !(await reverse) && await propertyCache;
+      return propertyCache && propertyCache[(await predicate).value];
     });
   }
 }

--- a/src/MutationFunctionHandler.js
+++ b/src/MutationFunctionHandler.js
@@ -68,7 +68,7 @@ export default class MutationFunctionHandler {
       throw new Error(`${pathData} should at least contain a subject and a predicate`);
 
     // Obtain the predicate and target objects
-    const { predicate } = conditions[conditions.length - 1];
+    const { predicate, reverse } = conditions[conditions.length - 1];
     if (!predicate)
       throw new Error(`Expected predicate in ${pathData}`);
     const objects = await this.extractObjects(pathData, path, values);
@@ -77,7 +77,7 @@ export default class MutationFunctionHandler {
     return objects !== null && objects.length === 0 ? {} : {
       mutationType: this._mutationType,
       conditions: conditions.slice(0, -1),
-      predicateObjects: [{ predicate, objects }],
+      predicateObjects: [{ predicate, reverse, objects }],
     };
   }
 

--- a/src/PathExpressionHandler.js
+++ b/src/PathExpressionHandler.js
@@ -12,6 +12,7 @@ export default class PathExpressionHandler {
       if (current.predicate) {
         segments.unshift({
           predicate: await current.predicate,
+          reverse: await current.reverse,
           sort: current.sort,
         });
       }

--- a/src/PreloadHandler.js
+++ b/src/PreloadHandler.js
@@ -83,6 +83,7 @@ export default class PreloadHandler {
 
     // Modify the query to include the preload clauses
     // TODO: instead of query manipulation, adjust the query generator
+    // TODO: support reverse predicates
     const vars = predicates.map((p, i) => `?preload_${i}`);
     const preloadClauses = predicates.map((predicate, i) =>
       `    { ${resultVar} <${predicate}> ${vars[i]}. }`)

--- a/src/SparqlHandler.js
+++ b/src/SparqlHandler.js
@@ -54,9 +54,11 @@ export default class SparqlHandler {
     // If there are no mutations, there is no query
     if (!mutationType || !conditions || predicateObjects && predicateObjects.length === 0)
       return '';
-    // If the only condition is a subject, we need no WHERE clause
+
+    // Create the WHERE clauses
     const scope = {};
     let subject, where;
+    // If the only condition is a subject, we need no WHERE clause
     if (conditions.length === 1) {
       subject = this.termToString(conditions[0].subject);
       where = [];
@@ -69,28 +71,28 @@ export default class SparqlHandler {
         this.expressionToTriplePatterns(conditions, subject, scope));
     }
 
-    const mutationPatterns = [];
+    // Create the mutation clauses
+    const mutations = [];
     for (const { predicate, reverse, objects } of predicateObjects) {
-      const objectList = !objects ?
-        // If no objects were listed, we need to mutate all of them
-        [this.createVar(predicate.value, scope)] :
-        // Otherwise, we need to mutate the listed objects
-        objects.map(o => this.termToString(o));
-      const predicateString = this.termToString(predicate);
-      if (!reverse) {
-        const objectString = objectList.join(', ');
-        mutationPatterns.push(`${subject} ${predicateString} ${objectString}.`);
-      }
-      else {
-        mutationPatterns.push(objectList.map(object =>
-          `${object} ${predicateString} ${subject}.`).join('\n  '));
-      }
+      // Mutate either only the specified objects, or all of them
+      const objectList = objects ?
+        objects.map(o => this.termToString(o)) :
+        [this.createVar(predicate.value, scope)];
+      // Swap subjects and objects for a reverse predicate
+      const [subjectStrings, objectStrings] = !reverse ?
+        [[subject], objectList.join(', ')] : [objectList, subject];
+      // Generate a triple pattern for all subjects
+      mutations.push(...subjectStrings.map(subjectString =>
+        this.triplePattern(subjectString, predicate, objectStrings)));
     }
+    const mutationClauses = `{\n  ${mutations.join('\n  ')}\n}`;
+
+    // Join clauses into a SPARQL query
     return where.length === 0 ?
       // If there are no WHERE clauses, just mutate raw data
-      `${mutationType} DATA {\n  ${mutationPatterns.join('\n  ')}\n}` :
+      `${mutationType} DATA ${mutationClauses}` :
       // Otherwise, return a DELETE/INSERT ... WHERE ... query
-      `${mutationType} {\n  ${mutationPatterns.join('\n  ')}\n} WHERE {\n  ${where.join('\n  ')}\n}`;
+      `${mutationType} ${mutationClauses} WHERE {\n  ${where.join('\n  ')}\n}`;
   }
 
   expressionToTriplePatterns([root, ...pathExpression], lastVar, scope = {}) {
@@ -103,9 +105,7 @@ export default class SparqlHandler {
       const subject = object;
       const { predicate, reverse, sort } = segment;
       object = index < lastIndex ? this.createVar(`v${index}`, scope) : lastVar;
-      const result = reverse ?
-        `${object} ${this.termToString(predicate)} ${subject}.` :
-        `${subject} ${this.termToString(predicate)} ${object}.`;
+      const patttern = this.triplePattern(subject, predicate, object, reverse);
 
       // If the sort option was not set, use this object as a query variable
       if (!sort) {
@@ -118,7 +118,7 @@ export default class SparqlHandler {
         // TODO: use a descriptive lastVar in case of sorting
         object = queryVar;
       }
-      return result;
+      return patttern;
     });
     return { queryVar, sorts, clauses };
   }
@@ -162,6 +162,13 @@ export default class SparqlHandler {
     default:
       throw new Error(`Could not convert a term of type ${term.termType}`);
     }
+  }
+
+  // Creates a triple pattern
+  triplePattern(subject, predicateTerm, object, reverse = false) {
+    if (reverse)
+      [subject, object] = [object, subject];
+    return `${subject} <${predicateTerm.value}> ${object}.`;
   }
 }
 

--- a/test/context.json
+++ b/test/context.json
@@ -6,6 +6,8 @@
     "firstName": "foaf:givenName",
     "givenName": "foaf:givenName",
     "familyName": "foaf:familyName",
+    "friendOf" : { "@reverse":  "foaf:knows" },
+    "makerOf" : { "@reverse":  "foaf:maker" },
     "name": "http://xmlns.com/foaf/0.1/name",
     "label": "http://www.w3.org/2000/01/rdf-schema#label"
   }

--- a/test/unit/JSONLDResolver-test.js
+++ b/test/unit/JSONLDResolver-test.js
@@ -176,6 +176,40 @@ describe('a JSONLDResolver instance with a context', () => {
     });
   });
 
+  describe('resolving the makerOf property', () => {
+    const extendedPath = {};
+    const pathData = { extendPath: jest.fn(() => extendedPath) };
+
+    let result;
+    beforeEach(() => result = resolver.resolve('makerOf', pathData));
+
+    it('extends the path', () => {
+      expect(pathData.extendPath).toBeCalledTimes(1);
+      const args = pathData.extendPath.mock.calls[0];
+      expect(args).toHaveLength(1);
+      expect(args[0]).toBeInstanceOf(Object);
+    });
+
+    it('sets property to makerOf', () => {
+      const { property } = pathData.extendPath.mock.calls[0][0];
+      expect(property).toBe('makerOf');
+    });
+
+    it('sets predicate to a promise for foaf:maker', async () => {
+      const { predicate } = pathData.extendPath.mock.calls[0][0];
+      expect(await predicate).toEqual(namedNode('http://xmlns.com/foaf/0.1/maker'));
+    });
+
+    it('sets the reverse property to a promise resolving to true', async () => {
+      const { reverse } = pathData.extendPath.mock.calls[0][0];
+      expect(await reverse).toBeTruthy();
+    });
+
+    it('returns the extended path', () => {
+      expect(result).toBe(extendedPath);
+    });
+  });
+
   describe('when the context is extended', () => {
     describe('before extending', () => {
       it('does not resolve sameAs', async () => {
@@ -243,6 +277,22 @@ describe('a JSONLDResolver instance with a context', () => {
         expect(args).toHaveLength(1);
         await expect(args[0].resultsCache).resolves.toBe(
           (await pathData.propertyCache)['http://xmlns.com/foaf/0.1/knows']);
+      });
+
+      it('returns the extended path', () => {
+        expect(result).toBe(extendedPath);
+      });
+    });
+
+    describe('when accessing the reverse of a cached property', () => {
+      let result;
+      beforeEach(() => result = resolver.resolve('friendOf', pathData));
+
+      it('extends the path without a results cache', async () => {
+        expect(pathData.extendPath).toBeCalledTimes(1);
+        const args = pathData.extendPath.mock.calls[0];
+        expect(args).toHaveLength(1);
+        await expect(args[0].resultsCache).resolves.toBeFalsy();
       });
 
       it('returns the extended path', () => {

--- a/test/unit/JSONLDResolver-test.js
+++ b/test/unit/JSONLDResolver-test.js
@@ -197,12 +197,12 @@ describe('a JSONLDResolver instance with a context', () => {
 
     it('sets predicate to a promise for foaf:maker', async () => {
       const { predicate } = pathData.extendPath.mock.calls[0][0];
-      expect(await predicate).toEqual(namedNode('http://xmlns.com/foaf/0.1/maker'));
+      await expect(predicate).resolves.toEqual(namedNode('http://xmlns.com/foaf/0.1/maker'));
     });
 
     it('sets the reverse property to a promise resolving to true', async () => {
       const { reverse } = pathData.extendPath.mock.calls[0][0];
-      expect(await reverse).toBeTruthy();
+      await expect(reverse).resolves.toBeTruthy();
     });
 
     it('returns the extended path', () => {

--- a/test/unit/MutationFunctionHandler-test.js
+++ b/test/unit/MutationFunctionHandler-test.js
@@ -457,6 +457,42 @@ describe('a MutationFunctionHandler instance not allowing 0 args', () => {
         .toEqual(await handler.createMutationExpressions(pathData, path, args1));
     });
   });
+
+  describe('with a reversed property', () => {
+    let pathExpression;
+    let result;
+    beforeEach(() => {
+      pathExpression = [
+        { subject: namedNode('https://example.org/#me') },
+        { predicate: namedNode('https://ex.org/p1'), reverse: true },
+      ];
+      result = handler.handle(pathData, { pathExpression });
+    });
+
+    describe('with the function called with one raw argument', () => {
+      let functionResult;
+      beforeEach(async () => functionResult = await result('Ruben'));
+
+      it('sets mutationExpressions to a promise to the expressions', async () => {
+        const { mutationExpressions } = pathData.extendPath.mock.calls[0][0];
+        expect(await mutationExpressions).toEqual([
+          {
+            mutationType,
+            conditions: [{ subject: namedNode('https://example.org/#me') }],
+            predicateObjects: [{
+              predicate: namedNode('https://ex.org/p1'),
+              reverse: true,
+              objects: [literal('Ruben')],
+            }],
+          },
+        ]);
+      });
+
+      it('returns the extended path', () => {
+        expect(functionResult).toEqual(extendedPath);
+      });
+    });
+  });
 });
 
 describe('a MutationFunctionHandler instance allowing 0 args', () => {

--- a/test/unit/PathExpressionHandler-test.js
+++ b/test/unit/PathExpressionHandler-test.js
@@ -55,12 +55,12 @@ describe('a PathExpressionHandler instance', () => {
   it('resolves a path with promises', async () => {
     const pathData = { subject: Promise.resolve(namedNode('abc')) };
     const first = { parent: pathData, predicate: Promise.resolve(namedNode('p1')) };
-    const second = { parent: first, predicate: Promise.resolve(namedNode('p2')) };
+    const second = { parent: first, predicate: Promise.resolve(namedNode('p2')), reverse: Promise.resolve(true) };
 
     expect(await handler.handle(second)).toEqual([
       { subject: namedNode('abc') },
       { predicate: namedNode('p1') },
-      { predicate: namedNode('p2') },
+      { predicate: namedNode('p2'), reverse: true },
     ]);
   });
 });


### PR DESCRIPTION
As requested in #14 .

This builds upon the changes made in #56 .

Currently property caches don't work with reversed predicates due to the cache only relying on the URI string, so more rework is required there should this be needed. (There are no wrong results, it simply wouldn't use the cache).

This only supports reversed predicates in the context though, so should this get added maybe it would also be interesting to add a function/property to support reversed properties in a path (e.g. `person.maker.reverse` or `person['@reverse:maker'` or something similar).