### PR TITLE
Support fixed values for predicates

### DIFF
--- a/src/JSONLDResolver.js
+++ b/src/JSONLDResolver.js
@@ -31,7 +31,23 @@ export default class JSONLDResolver {
     const reverse = lazyThenable(() => this._context.then(context =>
       context[property] && context[property]['@reverse']));
     const resultsCache = this.getResultsCache(pathData, predicate, reverse);
-    return pathData.extendPath({ property, predicate, resultsCache, reverse });
+    return pathData.extendPath({ property, predicate, resultsCache, reverse, asFunction: this.apply });
+  }
+
+  /**
+   * Function for fixing the object values of the predicate.
+   * Extends the proxy with the new values.
+   */
+  apply(pathData, args) {
+    if (!args || args.length === 0)
+      throw new Error('At least 1 argument is required');
+    if (args.some(arg => !arg.termType))
+      throw new Error('Args need to be RDF objects');
+    pathData.values = args;
+    // Prevent children from inheriting this apply function
+    delete pathData.asFunction;
+    // No extendPath call since we don't want to add a chain so return original proxy
+    return pathData.proxy;
   }
 
   /**

--- a/src/JSONLDResolver.js
+++ b/src/JSONLDResolver.js
@@ -25,7 +25,10 @@ export default class JSONLDResolver {
   }
 
   /**
-   * Resolves the property by extending the query path with it.
+   * When resolving a JSON-LD property,
+   * we create a new chainable path segment corresponding to the predicate.
+   *
+   * Example usage: person.friends.firstName
    */
   resolve(property, pathData) {
     const predicate = lazyThenable(() => this.expandProperty(property));
@@ -37,8 +40,10 @@ export default class JSONLDResolver {
   }
 
   /**
-   * Function for fixing the object values of the predicate.
-   * Extends the proxy with the new values.
+   * When the property is called as a function,
+   * it adds property-object constraints to the path.
+   *
+   * Example usage: person.friends.location(place).firstName
    */
   apply(args, pathData, path) {
     if (args.length === 0)

--- a/src/JSONLDResolver.js
+++ b/src/JSONLDResolver.js
@@ -31,23 +31,22 @@ export default class JSONLDResolver {
     const reverse = lazyThenable(() => this._context.then(context =>
       context[property] && context[property]['@reverse']));
     const resultsCache = this.getResultsCache(pathData, predicate, reverse);
-    return pathData.extendPath({ property, predicate, resultsCache, reverse, asFunction: this.apply });
+    const newData = { property, predicate, resultsCache, reverse, apply: this.apply };
+    return pathData.extendPath(newData);
   }
 
   /**
    * Function for fixing the object values of the predicate.
    * Extends the proxy with the new values.
    */
-  apply(pathData, args) {
+  apply(args, pathData, path) {
     if (!args || args.length === 0)
-      throw new Error('At least 1 argument is required');
+      throw new Error('Specify at least one value for the property');
     if (args.some(arg => !arg.termType))
-      throw new Error('Args need to be RDF objects');
+      throw new TypeError('All arguments should be RDF terms');
     pathData.values = args;
-    // Prevent children from inheriting this apply function
-    delete pathData.asFunction;
-    // No extendPath call since we don't want to add a chain so return original proxy
-    return pathData.proxy;
+    // With the property constraint added, continue from the previous path
+    return path;
   }
 
   /**

--- a/src/JSONLDResolver.js
+++ b/src/JSONLDResolver.js
@@ -1,6 +1,7 @@
 import { ContextParser } from 'jsonld-context-parser';
 import { namedNode } from '@rdfjs/data-model';
 import { lazyThenable } from './promiseUtils';
+import { valueToTerm } from './valueUtils';
 
 /**
  * Resolves property names of a path
@@ -40,12 +41,10 @@ export default class JSONLDResolver {
    * Extends the proxy with the new values.
    */
   apply(args, pathData, path) {
-    if (!args || args.length === 0)
+    if (args.length === 0)
       throw new Error('Specify at least one value for the property');
-    if (args.some(arg => !arg.termType))
-      throw new TypeError('All arguments should be RDF terms');
-    pathData.values = args;
     // With the property constraint added, continue from the previous path
+    pathData.values = args.map(valueToTerm);
     return path;
   }
 

--- a/src/MutationFunctionHandler.js
+++ b/src/MutationFunctionHandler.js
@@ -31,7 +31,7 @@ export default class MutationFunctionHandler {
     return (...args) => {
       // Check if the given arguments are valid
       if (!this._allowZeroArgs && !args.length)
-        throw new Error(`Mutation on ${pathData} can not be invoked without arguments`);
+        throw new Error('Mutation cannot be invoked without arguments');
 
       // Create a lazy Promise to the mutation expressions
       const mutationExpressions = lazyThenable(() =>

--- a/src/PathExpressionHandler.js
+++ b/src/PathExpressionHandler.js
@@ -14,6 +14,7 @@ export default class PathExpressionHandler {
           predicate: await current.predicate,
           reverse: await current.reverse,
           sort: current.sort,
+          values: current.values,
         });
       }
       // Move to parent link

--- a/test/integration/execute-query-test.js
+++ b/test/integration/execute-query-test.js
@@ -9,11 +9,13 @@ import SubjectsHandler from '../../src/SubjectsHandler';
 import SetFunctionHandler from '../../src/SetFunctionHandler';
 import DataHandler from '../../src/DataHandler';
 import JSONLDResolver from '../../src/JSONLDResolver';
+import MutationExpressionsHandler from '../../src/MutationExpressionsHandler';
 import { createQueryEngine, deindent } from '../util';
 import { namedNode, literal } from '@rdfjs/data-model';
 import { iterableToArray } from '../../src/iterableUtils';
 
 import context from '../context';
+import ThenHandler from '../../src/ThenHandler';
 
 const subject = namedNode('https://example.org/#me');
 const queryEngine = createQueryEngine([
@@ -26,6 +28,8 @@ const resolvers = [
   new JSONLDResolver(context),
 ];
 const handlersPath = {
+  then: new ThenHandler(),
+  mutationExpressions: new MutationExpressionsHandler(),
   sparql: new SparqlHandler(),
   pathExpression: new PathExpressionHandler(),
   results: new ExecuteQueryHandler(),
@@ -38,6 +42,8 @@ const handlersPath = {
 };
 
 const handlersMutation = {
+  then: new ThenHandler(),
+  mutationExpressions: new MutationExpressionsHandler(),
   sparql: new SparqlHandler(),
   pathExpression: new PathExpressionHandler(),
   results: new ExecuteQueryHandler(),
@@ -119,6 +125,12 @@ describe('a query path with a path and mutation expression handler', () => {
 
   it('returns results for a path with 3 links', async () => {
     const names = await iterableToArray(person.friends.firstName);
+    expect(names.map(n => `${n}`)).toEqual(['Alice', 'Bob', 'Carol']);
+  });
+
+  it('returns results for a path with 4 links and fixed values', async () => {
+    const names = await iterableToArray(
+      person.friends.friends(namedNode('http://ex.org/John')).firstName);
     expect(names.map(n => `${n}`)).toEqual(['Alice', 'Bob', 'Carol']);
   });
 

--- a/test/integration/sparql-test.js
+++ b/test/integration/sparql-test.js
@@ -81,6 +81,27 @@ describe('a query path with a path expression handler', () => {
       ORDER BY ASC(?v3) ASC(?givenName)`));
   });
 
+  it('resolves a path with 3 links and fixed values', async () => {
+    const query = await person.friends.friends(namedNode('http://ex.org/Alice'), namedNode('http://ex.org/Bob')).name.sparql;
+    expect(query).toEqual(deindent(`
+      SELECT ?name WHERE {
+        <https://example.org/#me> <http://xmlns.com/foaf/0.1/knows> ?v0.
+        ?v0 <http://xmlns.com/foaf/0.1/knows> <http://ex.org/Alice>, <http://ex.org/Bob>.
+        ?v0 <http://xmlns.com/foaf/0.1/name> ?name.
+      }`));
+  });
+
+  it('resolves a path with 3 links and reversed fixed values', async () => {
+    const query = await person.friends.friendOf(namedNode('http://ex.org/Alice'), namedNode('http://ex.org/Bob')).name.sparql;
+    expect(query).toEqual(deindent(`
+      SELECT ?name WHERE {
+        <https://example.org/#me> <http://xmlns.com/foaf/0.1/knows> ?v0.
+        <http://ex.org/Alice> <http://xmlns.com/foaf/0.1/knows> ?v0.
+        <http://ex.org/Bob> <http://xmlns.com/foaf/0.1/knows> ?v0.
+        ?v0 <http://xmlns.com/foaf/0.1/name> ?name.
+      }`));
+  });
+
   it('resolves a path with 1 link and a predicates call', async () => {
     const query = await person.predicates.sparql;
     expect(query).toEqual(deindent(`
@@ -183,7 +204,7 @@ describe('a query path with a path expression handler', () => {
 
   it('errors on a path with 3 links and an addition without args', async () => {
     expect(() => person.friends.friends.add().sparql)
-      .toThrow(new Error('Mutation on [object Object] can not be invoked without arguments'));
+      .toThrow();
   });
 
   it('resolves a path with 3 links and an addition with a raw arg and path arg', async () => {

--- a/test/integration/sparql-test.js
+++ b/test/integration/sparql-test.js
@@ -204,7 +204,7 @@ describe('a query path with a path expression handler', () => {
 
   it('errors on a path with 3 links and an addition without args', async () => {
     expect(() => person.friends.friends.add().sparql)
-      .toThrow();
+      .toThrow(new Error('Mutation cannot be invoked without arguments'));
   });
 
   it('resolves a path with 3 links and an addition with a raw arg and path arg', async () => {

--- a/test/unit/JSONLDResolver-test.js
+++ b/test/unit/JSONLDResolver-test.js
@@ -60,39 +60,40 @@ describe('a JSONLDResolver instance with a context', () => {
     });
   });
 
-  describe('resolving properties as functions', () => {
-    const pathData = { extendPath: jest.fn(x => Object.assign(x, { proxy: x })) };
+  describe('resolving the knows property and calling it as a function', () => {
+    const path = {};
+    const pathData = { extendPath: jest.fn(data => ({ ...data })) };
 
     let result;
     beforeEach(() => result = resolver.resolve('knows', pathData));
 
-    it('exists', () => {
-      result = resolver.resolve('knows', pathData);
-      expect(result.asFunction).toBeInstanceOf(Function);
+    it('sets up the function through apply', () => {
+      expect(result.apply).toBeInstanceOf(Function);
     });
 
     it('errors if there are no arguments', () => {
-      expect(() => result.asFunction(result, [])).toThrowError();
+      expect(() => result.apply([], result, path))
+        .toThrow(new Error('Specify at least one value for the property'));
     });
 
     it('errors if the input is not an RDF object', () => {
-      expect(() => result.asFunction(result, ['Ruben'])).toThrowError();
+      expect(() => result.apply(['Ruben'], result, path))
+        .toThrow(new Error('All arguments should be RDF terms'));
     });
 
     describe('with 2 values', () => {
       const ruben = namedNode('Ruben');
       const joachim = namedNode('Joachim');
+
       let applied;
-      beforeEach(() => {
-        applied = result.asFunction(result, [ruben, joachim]);
+      beforeEach(() => applied = result.apply([ruben, joachim], result, path));
+
+      it('returns the proxied path', () => {
+        expect(applied).toBe(path);
       });
 
       it('stores the new values in the result', () => {
-        expect(applied.values).toEqual([ruben, joachim]);
-      });
-
-      it('deletes the asFunction property', () => {
-        expect(applied).not.toHaveProperty('asFunction');
+        expect(result.values).toEqual([ruben, joachim]);
       });
     });
   });

--- a/test/unit/JSONLDResolver-test.js
+++ b/test/unit/JSONLDResolver-test.js
@@ -1,6 +1,6 @@
 import JSONLDResolver from '../../src/JSONLDResolver';
 import context from '../context';
-import { namedNode } from '@rdfjs/data-model';
+import { namedNode, literal } from '@rdfjs/data-model';
 
 describe('a JSONLDResolver instance', () => {
   let resolver;
@@ -76,12 +76,20 @@ describe('a JSONLDResolver instance with a context', () => {
         .toThrow(new Error('Specify at least one value for the property'));
     });
 
-    it('errors if the input is not an RDF object', () => {
-      expect(() => result.apply(['Ruben'], result, path))
-        .toThrow(new Error('All arguments should be RDF terms'));
+    describe('with two strings', () => {
+      let applied;
+      beforeEach(() => applied = result.apply(['Ruben', 'Joachim'], result, path));
+
+      it('returns the proxied path', () => {
+        expect(applied).toBe(path);
+      });
+
+      it('stores the new values in the result', () => {
+        expect(result.values).toEqual([literal('Ruben'), literal('Joachim')]);
+      });
     });
 
-    describe('with 2 values', () => {
+    describe('with 2 terms', () => {
       const ruben = namedNode('Ruben');
       const joachim = namedNode('Joachim');
 

--- a/test/unit/JSONLDResolver-test.js
+++ b/test/unit/JSONLDResolver-test.js
@@ -60,6 +60,43 @@ describe('a JSONLDResolver instance with a context', () => {
     });
   });
 
+  describe('resolving properties as functions', () => {
+    const pathData = { extendPath: jest.fn(x => Object.assign(x, { proxy: x })) };
+
+    let result;
+    beforeEach(() => result = resolver.resolve('knows', pathData));
+
+    it('exists', () => {
+      result = resolver.resolve('knows', pathData);
+      expect(result.asFunction).toBeInstanceOf(Function);
+    });
+
+    it('errors if there are no arguments', () => {
+      expect(() => result.asFunction(result, [])).toThrowError();
+    });
+
+    it('errors if the input is not an RDF object', () => {
+      expect(() => result.asFunction(result, ['Ruben'])).toThrowError();
+    });
+
+    describe('with 2 values', () => {
+      const ruben = namedNode('Ruben');
+      const joachim = namedNode('Joachim');
+      let applied;
+      beforeEach(() => {
+        applied = result.asFunction(result, [ruben, joachim]);
+      });
+
+      it('stores the new values in the result', () => {
+        expect(applied.values).toEqual([ruben, joachim]);
+      });
+
+      it('deletes the asFunction property', () => {
+        expect(applied).not.toHaveProperty('asFunction');
+      });
+    });
+  });
+
   describe('resolving the foaf:knows property', () => {
     const extendedPath = {};
     const pathData = { extendPath: jest.fn(() => extendedPath) };

--- a/test/unit/MutationFunctionHandler-test.js
+++ b/test/unit/MutationFunctionHandler-test.js
@@ -90,7 +90,7 @@ describe('a MutationFunctionHandler instance not allowing 0 args', () => {
     describe('with the function called without arguments', () => {
       it('errors when the function is invoked without arguments', async () => {
         expect(() => result())
-          .toThrow(new Error('Mutation on path can not be invoked without arguments'));
+          .toThrow(new Error('Mutation cannot be invoked without arguments'));
       });
     });
   });

--- a/test/unit/PathProxy-test.js
+++ b/test/unit/PathProxy-test.js
@@ -22,8 +22,24 @@ describe('a PathProxy without handlers or resolvers', () => {
 
     describe('when calling it as a function', () => {
       it('throws an error', () => {
-        expect(path()).toBeUndefined();
+        expect(() => path()).toThrow(new TypeError('path is not a function'));
       });
+    });
+  });
+
+  describe('a created path with an apply setting', () => {
+    let path, apply;
+    beforeAll(() => {
+      apply = jest.fn(args => `result: ${args[0]}`);
+      path = pathProxy.createPath({ apply });
+    });
+
+    it('calls the apply function when called', () => {
+      expect(path('test')).toBe('result: test');
+      expect(apply).toHaveBeenCalledTimes(1);
+      const args = apply.mock.calls[0];
+      expect(args[0]).toEqual(['test']);
+      expect(typeof args[1].apply).toBe('function');
     });
   });
 });
@@ -337,27 +353,6 @@ describe('a PathProxy whose paths are extended', () => {
     it('contains a reference to the settings', () => {
       expect(path.internal).toHaveProperty('settings');
       expect(path.internal.settings).toBe(settings);
-    });
-  });
-});
-
-describe('a PathProxy with an apply function', () => {
-  let pathProxy;
-  beforeAll(() => (pathProxy = new PathProxy()));
-
-  describe('a created path', () => {
-    let path, f;
-    beforeAll(() => {
-      f = jest.fn(x => x);
-      path = pathProxy.createPath({ asFunction: f });
-    });
-
-    it('calls the apply function', () => {
-      path('test');
-      expect(f).toBeCalledTimes(1);
-      const args = f.mock.calls[0];
-      expect(typeof args[0].asFunction).toBe('function');
-      expect(args[1]).toEqual(['test']);
     });
   });
 });

--- a/test/unit/PathProxy-test.js
+++ b/test/unit/PathProxy-test.js
@@ -19,6 +19,12 @@ describe('a PathProxy without handlers or resolvers', () => {
         expect(path[Symbol('symbol')]).toBeUndefined();
       });
     });
+
+    describe('when calling it as a function', () => {
+      it('throws an error', () => {
+        expect(path()).toBeUndefined();
+      });
+    });
   });
 });
 
@@ -331,6 +337,27 @@ describe('a PathProxy whose paths are extended', () => {
     it('contains a reference to the settings', () => {
       expect(path.internal).toHaveProperty('settings');
       expect(path.internal.settings).toBe(settings);
+    });
+  });
+});
+
+describe('a PathProxy with an apply function', () => {
+  let pathProxy;
+  beforeAll(() => (pathProxy = new PathProxy()));
+
+  describe('a created path', () => {
+    let path, f;
+    beforeAll(() => {
+      f = jest.fn(x => x);
+      path = pathProxy.createPath({ asFunction: f });
+    });
+
+    it('calls the apply function', () => {
+      path('test');
+      expect(f).toBeCalledTimes(1);
+      const args = f.mock.calls[0];
+      expect(typeof args[0].asFunction).toBe('function');
+      expect(args[1]).toEqual(['test']);
     });
   });
 });

--- a/test/unit/SparqlHandler-test.js
+++ b/test/unit/SparqlHandler-test.js
@@ -208,7 +208,8 @@ describe('a SparqlHandler instance', () => {
       ];
 
       const pathData = { property: 'p2' };
-      await expect(handler.handle(pathData, { pathExpression })).rejects.toEqual(new Error('Can not have static objects if the subject is also static'));
+      await expect(handler.handle(pathData, { pathExpression })).rejects
+        .toEqual(new Error('Specifying fixed values is not allowed here'));
     });
 
     it('supports reversed fixed values', async () => {


### PR DESCRIPTION
As requested in #40 .

This depends on #58.

There are several ways this could have been implemented. In the current implementation handlers have to set a value on the proxy they create (`asFunction`). Should the proxy then be called as a function that function that has been set will then be called. The reason this is called `asFunction` instead of `apply` is because in JavaScript functions allready have an `apply` property.

Another solution could have been to force all handlers to have a function to be called when `apply` is called in the proxy. Or to register apply calls similarly to handlers are currently registered. This last one might be more consistent with the current implementation, but it seemed not that useful to me since the handle call will always be called first before the apply call anyway.

This does mean that there are currently two ways to call a function on the proxy path: have the handle function return a function (as was the case on existing handlers), or return a proxy that has the `asFunction` property. All of the first cases can be rewritten as the second case if required (but the other way can't because otherwise this pull request would be quite useless).

An issue with this pull request is that test coverage doesn't cover all function calls 100% anymore since the root proxy object is an empty function that can never be called :D . If this is an issue I can look for a workaround there.