### PR TITLE
Fix issue if object maps have different conditions

### DIFF
--- a/test/integration/mutation-expressions-test.js
+++ b/test/integration/mutation-expressions-test.js
@@ -202,4 +202,26 @@ describe('a query path with a path expression handler', () => {
       },
     ]);
   });
+
+  it('resolves a path where an object map has different conditions', async () => {
+    const path = await person.delete({ friends: null, firstName: 'ruben' }).mutationExpressions;
+    expect(path).toEqual([
+      {
+        mutationType: 'DELETE',
+        conditions: [
+          { subject },
+        ],
+        predicateObjects: [
+          {
+            predicate: namedNode('http://xmlns.com/foaf/0.1/knows'),
+            objects: null,
+          },
+          {
+            predicate: namedNode('http://xmlns.com/foaf/0.1/givenName'),
+            objects: [literal('ruben')],
+          },
+        ],
+      },
+    ]);
+  });
 });

--- a/test/integration/sparql-test.js
+++ b/test/integration/sparql-test.js
@@ -175,10 +175,9 @@ describe('a query path with a path expression handler', () => {
     const query = await person.friends.friends.delete().sparql;
     expect(query).toEqual(deindent(`
       DELETE {
-        ?v0 <${FOAF}knows> ?knows.
+        ?knows <${FOAF}knows> ?knows_0.
       } WHERE {
-        <https://example.org/#me> <${FOAF}knows> ?v0.
-        ?v0 <${FOAF}knows> ?knows.
+        <https://example.org/#me> <${FOAF}knows> ?knows.
       }`));
   });
 
@@ -209,6 +208,15 @@ describe('a query path with a path expression handler', () => {
       }`));
   });
 
+  it('resolves a path where an object map has different conditions', async () => {
+    const query = await person.delete({ friends: null, firstName: 'Ruben' }).sparql;
+    expect(query).toEqual(deindent(`
+      DELETE DATA {
+        <https://example.org/#me> <${FOAF}knows> ?knows.
+        <https://example.org/#me> <${FOAF}givenName> "Ruben".
+      }`));
+  });
+
   it('resolves a path with 3 links and a deletion and addition', async () => {
     const query = await person.friends.friends.firstName.delete('ruben').add('Ruben').sparql;
     expect(query).toEqual(deindent(`
@@ -231,11 +239,10 @@ describe('a query path with a path expression handler', () => {
     const query = await person.friends.friends.firstName.set('Ruben').sparql;
     expect(query).toEqual(deindent(`
       DELETE {
-        ?v1 <${FOAF}givenName> ?givenName.
+        ?knows <${FOAF}givenName> ?givenName.
       } WHERE {
         <https://example.org/#me> <${FOAF}knows> ?v0.
-        ?v0 <${FOAF}knows> ?v1.
-        ?v1 <${FOAF}givenName> ?givenName.
+        ?v0 <${FOAF}knows> ?knows.
       }
       ;
       INSERT {
@@ -250,11 +257,10 @@ describe('a query path with a path expression handler', () => {
     const query = await person.friends.friends.firstName.set('Ruben', 'ruben').sparql;
     expect(query).toEqual(deindent(`
       DELETE {
-        ?v1 <${FOAF}givenName> ?givenName.
+        ?knows <${FOAF}givenName> ?givenName.
       } WHERE {
         <https://example.org/#me> <${FOAF}knows> ?v0.
-        ?v0 <${FOAF}knows> ?v1.
-        ?v1 <${FOAF}givenName> ?givenName.
+        ?v0 <${FOAF}knows> ?knows.
       }
       ;
       INSERT {

--- a/test/unit/MutationFunctionHandler-test.js
+++ b/test/unit/MutationFunctionHandler-test.js
@@ -476,7 +476,9 @@ describe('a MutationFunctionHandler instance allowing 0 args', () => {
             mutationType,
             conditions: [
               { subject: namedNode('https://example.org/#me') },
-              { predicate: namedNode('https://ex.org/p1') },
+            ],
+            predicateObjects: [
+              { predicate: namedNode('https://ex.org/p1'), objects: null },
             ],
           },
         ]);
@@ -497,7 +499,9 @@ describe('a MutationFunctionHandler instance allowing 0 args', () => {
               { subject: namedNode('https://example.org/#me') },
               { predicate: namedNode('https://ex.org/p1') },
               { predicate: namedNode('https://ex.org/p2') },
-              { predicate: namedNode('https://ex.org/p3') },
+            ],
+            predicateObjects: [
+              { predicate: namedNode('https://ex.org/p3'), objects: null },
             ],
           },
         ]);

--- a/test/unit/SparqlHandler-test.js
+++ b/test/unit/SparqlHandler-test.js
@@ -349,15 +349,15 @@ describe('a SparqlHandler instance', () => {
             mutationType: 'DELETE',
             conditions: [
               { subject: namedNode('https://example.org/#D0') },
-              { predicate: namedNode('https://example.org/#Dp1') },
+            ],
+            predicateObjects: [
+              { predicate: namedNode('https://example.org/#Dp1'), objects: null },
             ],
           },
         ];
 
         expect(await handler.handle({}, { mutationExpressions })).toEqual(deindent(`
-          DELETE {
-            <https://example.org/#D0> <https://example.org/#Dp1> ?Dp1.
-          } WHERE {
+          DELETE DATA {
             <https://example.org/#D0> <https://example.org/#Dp1> ?Dp1.
           }`));
       });


### PR DESCRIPTION
This fixes #60 .

With this solution mutations always have a predicateObjects field. The objects field is simply null if it applies to everything. This reduces the amount of different cases that have to be taken into account and also simplifies some queries.

Also includes a fix for the getVariable function.