### PR TITLE
Fix bug where inverse path is sometimes not applied

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "ldflex",
-      "version": "2.11.1",
+      "version": "2.12.0",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/data-model": "^1.1.2",
@@ -31,7 +31,6 @@
       "integrity": "sha512-XXLgAm6LBbaNxaGhMAznXXaxtCWfuv6PIDJ9Alsy9JYTOh+j2jJz+L/162kkfU1j/pTSxK1xGmlwI4pdIMkoag==",
       "dev": true,
       "dependencies": {
-        "chokidar": "^2.1.8",
         "commander": "^4.0.1",
         "convert-source-map": "^1.1.0",
         "fs-readdir-recursive": "^1.1.0",
@@ -1507,7 +1506,6 @@
         "jest-resolve": "^25.4.0",
         "jest-util": "^25.4.0",
         "jest-worker": "^25.4.0",
-        "node-notifier": "^6.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^3.1.0",
@@ -3370,8 +3368,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -6455,7 +6452,6 @@
         "@jest/types": "^25.4.0",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.3",
         "jest-serializer": "^25.2.6",
         "jest-util": "^25.4.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "build:module": "babel src --env-name module --out-dir module",
     "jest": "jest",
     "lint": "eslint src test",
+    "lint:fix": "eslint src test --fix",
     "prepublishOnly": "npm run build",
     "test": "npm run lint && npm run jest -- --collectCoverage",
     "test:dev": "npm run jest -- --watch"

--- a/test/integration/sparql-test.js
+++ b/test/integration/sparql-test.js
@@ -377,6 +377,33 @@ describe('a query path with a path expression handler', () => {
     `));
   });
 
+  it('complex inverse and alternative path', async () => {
+    const query = await person[`(^<${FOAF}knows>)|(^<${FOAF}employee>)`].sparql;
+    expect(query).toEqual(deindent(`
+      SELECT ?result WHERE {
+        <https://example.org/#me> ^<${FOAF}knows>|^<${FOAF}employee> ?result.
+      }
+    `));
+  });
+
+  it('complex inverse and sequence path', async () => {
+    const query = await person[`(^<${FOAF}knows>)/(^<${FOAF}employee>)`].sparql;
+    expect(query).toEqual(deindent(`
+      SELECT ?result WHERE {
+        <https://example.org/#me> ^<${FOAF}knows>/^<${FOAF}employee> ?result.
+      }
+    `));
+  });
+
+  it('complex inverse and paths in sequence', async () => {
+    const query = await person[`^<${FOAF}knows>`][`^<${FOAF}employee>`].sparql;
+    expect(query).toEqual(deindent(`
+      SELECT ?result WHERE {
+        <https://example.org/#me> ^<${FOAF}knows> ?v0.
+        ?v0 ^<${FOAF}employee> ?result.
+      }
+    `));
+  });
 
   it('extra complex path test', async () => {
     const query = await person[`((<${FOAF}knows>|<${FOAF}employee>)*/foaf:friend?)+`].sparql;

--- a/test/integration/sparql-test.js
+++ b/test/integration/sparql-test.js
@@ -395,6 +395,48 @@ describe('a query path with a path expression handler', () => {
     `));
   });
 
+  it('complex inverse and extended sequence path', async () => {
+    const query = await person[`(^<${FOAF}knows>)/(^<${FOAF}employee>)/(^<${FOAF}employee>)`].sparql;
+    expect(query).toEqual(deindent(`
+      SELECT ?result WHERE {
+        <https://example.org/#me> ^<${FOAF}knows>/^<${FOAF}employee>/^<${FOAF}employee> ?result.
+      }
+    `));
+  });
+
+  it('mixed complex/inverse and extended sequence path(s)', async () => {
+    const queryOne = await person[`(^<${FOAF}knows>)/(<${FOAF}knows>)/(^<${FOAF}employee>)/(^<${FOAF}employee>)`].sparql;
+    const queryTwo = await person[`(^<${FOAF}knows>)/(^<${FOAF}knows>)/(^<${FOAF}employee>)/(^<${FOAF}employee>)`].sparql;
+    const queryThree = await person[`(^<${FOAF}knows>)/(^<${FOAF}knows>)/(^<${FOAF}employee>)/(<${FOAF}employee>)`].sparql;
+    const queryFour = await person[`(^<${FOAF}knows>)/(^<${FOAF}knows>)/(<${FOAF}employee>)/(<${FOAF}employee>)`].sparql;
+    const queryFive = await person[`(<${FOAF}knows>)/(^<${FOAF}knows>)/(<${FOAF}employee>)/(<${FOAF}employee>)`].sparql;
+    expect(queryOne).toEqual(deindent(`
+      SELECT ?result WHERE {
+        <https://example.org/#me> ^<${FOAF}knows>/<${FOAF}knows>/^<${FOAF}employee>/^<${FOAF}employee> ?result.
+      }
+    `));
+    expect(queryTwo).toEqual(deindent(`
+      SELECT ?result WHERE {
+        <https://example.org/#me> ^<${FOAF}knows>/^<${FOAF}knows>/^<${FOAF}employee>/^<${FOAF}employee> ?result.
+      }
+    `));
+    expect(queryThree).toEqual(deindent(`
+      SELECT ?result WHERE {
+        <https://example.org/#me> ^<${FOAF}knows>/^<${FOAF}knows>/^<${FOAF}employee>/<${FOAF}employee> ?result.
+      }
+    `));
+    expect(queryFour).toEqual(deindent(`
+      SELECT ?result WHERE {
+        <https://example.org/#me> ^<${FOAF}knows>/^<${FOAF}knows>/<${FOAF}employee>/<${FOAF}employee> ?result.
+      }
+    `));
+    expect(queryFive).toEqual(deindent(`
+      SELECT ?result WHERE {
+        <https://example.org/#me> <${FOAF}knows>/^<${FOAF}knows>/<${FOAF}employee>/<${FOAF}employee> ?result.
+      }
+    `));
+  });
+
   it('complex inverse and paths in sequence', async () => {
     const query = await person[`^<${FOAF}knows>`][`^<${FOAF}employee>`].sparql;
     expect(query).toEqual(deindent(`

--- a/test/integration/sparql-test.js
+++ b/test/integration/sparql-test.js
@@ -323,6 +323,24 @@ describe('a query path with a path expression handler', () => {
     `));
   });
 
+  it('resolves inverse path expressions', async () => {
+    const query = await person[`^<${FOAF}knows>`].sparql;
+    expect(query).toEqual(deindent(`
+      SELECT ?result WHERE {
+        <https://example.org/#me> ^<${FOAF}knows> ?result.
+      }
+    `));
+  });
+
+  it('resolves inverse path expressions with prefix', async () => {
+    const query = await person['^foaf:knows'].sparql;
+    expect(query).toEqual(deindent(`
+      SELECT ?knows WHERE {
+        <https://example.org/#me> ^<${FOAF}knows> ?knows.
+      }
+    `));
+  });
+
   it('resolves sparql sequence path expressions as predicates and resolves path modifiers', async () => {
     const query = await person[`(<${FOAF}knows>/<${FOAF}givenName>)*`].sparql;
     expect(query).toEqual(deindent(`

--- a/test/unit/ComplexPathResolver-test.js
+++ b/test/unit/ComplexPathResolver-test.js
@@ -6,7 +6,7 @@ describe('a ComplexPathResolver instance', () => {
   let resolver;
   beforeAll(() => resolver = new ComplexPathResolver());
 
-  it('does not support strings that are not complext paths', () => {
+  it('does not support strings that are not complex paths', () => {
     expect(resolver.supports('foo')).toBe(false);
   });
 
@@ -58,7 +58,7 @@ describe('Error handling on complex paths without prefixes defined', () => {
   let resolver;
   beforeAll(() => resolver = new ComplexPathResolver());
 
-  it('does not support strings that are not complext paths', async () => {
+  it('does not support strings that are not complex paths', async () => {
     await expect(() => resolver.expandProperty('foaf:friend*')).rejects
       .toThrow('The Complex Path Resolver cannot expand the \'foaf:friend*\' path');
   });

--- a/test/unit/ComplexPathResolver-test.js
+++ b/test/unit/ComplexPathResolver-test.js
@@ -74,6 +74,11 @@ describe('a ComplexPathResolver instance with a context', () => {
         .toEqual({ termType: 'path', value: '<http://xmlns.com/foaf/0.1/knows>*' });
     });
 
+    it('expands knows to ^foaf:knows', async () => {
+      expect(await resolver.expandProperty('^foaf:knows'))
+        .toEqual({ termType: 'path', value: '^<http://xmlns.com/foaf/0.1/knows>' });
+    });
+
     it('expands knows to foaf:knows*/foaf:friend+', async () => {
       expect(await resolver.expandProperty('foaf:knows*/foaf:friend+'))
         .toEqual({ termType: 'path', value: '<http://xmlns.com/foaf/0.1/knows>*/<http://xmlns.com/foaf/0.1/friend>+' });
@@ -92,6 +97,28 @@ describe('a ComplexPathResolver instance with a context', () => {
     it('errors when expanding a variable property', async () => {
       await expect(resolver.expandProperty('?p')).rejects
         .toThrow(new Error('The Complex Path Resolver cannot expand the \'?p\' path'));
+    });
+  });
+
+  describe('applying unary operators to single IRI', () => {
+    it('*', async () => {
+      expect(await resolver.expandProperty('<http://xmlns.com/foaf/0.1/knows>*'))
+        .toEqual({ termType: 'path', value: '<http://xmlns.com/foaf/0.1/knows>*' });
+    });
+
+    it('+', async () => {
+      expect(await resolver.expandProperty('<http://xmlns.com/foaf/0.1/knows>+'))
+        .toEqual({ termType: 'path', value: '<http://xmlns.com/foaf/0.1/knows>+' });
+    });
+
+    it('?', async () => {
+      expect(await resolver.expandProperty('<http://xmlns.com/foaf/0.1/knows>?'))
+        .toEqual({ termType: 'path', value: '<http://xmlns.com/foaf/0.1/knows>?' });
+    });
+
+    it('^', async () => {
+      expect(await resolver.expandProperty('^<http://xmlns.com/foaf/0.1/knows>'))
+        .toEqual({ termType: 'path', value: '^<http://xmlns.com/foaf/0.1/knows>' });
     });
   });
 


### PR DESCRIPTION
This pull request resolves #85.

The problem was that the BGP expansion from sparqlalgebrajs handles inverse paths by switching the subject and object and I ignored this in my initial implementation of the `ComplexPathResolver`.

Note for future:
Long term the `join` and `bgp` types would be better handled by recursively applying `.expandPath` so that `path['foaf:friend/foaf:friend']` would produce with the same in-memory representation as `path.friend.friend`.