### PR TITLE
feat: add URI handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ const context = {
     "@vocab": "http://xmlns.com/foaf/0.1/",
     "friends": "knows",
     "label": "http://www.w3.org/2000/01/rdf-schema#label",
+    "rbn": "https://ruben.verborgh.org/profile/#"
   }
 };
 // The query engine and its source
@@ -173,6 +174,13 @@ Alternatively, `.collection` can be used for *any* collection (i.e. `rdf:List`, 
   // Returns an Array of Authors
   const authors = await publication['bibo:authorList'].collection();
 })(ordonez_medellin_2014);
+```
+
+### NamedNode URI utilities
+```js
+ruben.namespace // 'https://ruben.verborgh.org/profile/#'
+ruben.fragment // 'me'
+await ruben.prefix // 'rbn'
 ```
 
 ## Additional Handlers

--- a/src/URIHandler.js
+++ b/src/URIHandler.js
@@ -5,7 +5,8 @@ import { handler } from './handlerUtil';
  * occurs - then execute a callback with this index as the second arg
  */
 function breakIndex(term, cb) {
-  if (term?.termType !== 'NamedNode') return undefined;
+  if (term?.termType !== 'NamedNode')
+    return undefined;
   // Find the index of the last '#' or '/' if no '#' exists
   const hashIndex = term.value.lastIndexOf('#');
   return cb(term.value, hashIndex === -1 ? term.value.lastIndexOf('/') : hashIndex);

--- a/src/URIHandler.js
+++ b/src/URIHandler.js
@@ -1,0 +1,36 @@
+import { handler } from './handlerUtil'
+
+const NAMESPACE = /^[^]*[#\/]/;
+const FRAGMENT = /(?![\/#])[^\/#]*$/
+
+/**
+ * Match the value of a NamedNode against a regular expression
+ */
+function match(term, pattern) {
+  return term?.termType === 'NamedNode'
+    ? pattern.exec(term.value)?.[0]
+    : undefined;
+}
+
+/**
+ * Gets the namespace of a NamedNode subject
+ */
+export const namespaceHandler = handler(({ subject }) => match(subject, NAMESPACE));
+
+/**
+ * Gets the fragment of a NamedNode subject
+ */
+export const fragmentHandler = handler(({ subject }) => match(subject, FRAGMENT));
+
+/**
+ * Gets the prefix of a NamedNode subject
+ */
+export const prefixHandler = handler(async (data) => {
+  const context = await data.settings.parsedContext;
+  const ns = namespaceHandler.handle(data);
+  for (const key in context) {
+    if (typeof key === 'string' && context[key] === ns) {
+      return key;
+    }
+  }
+})

--- a/src/URIHandler.js
+++ b/src/URIHandler.js
@@ -1,15 +1,15 @@
-import { handler } from './handlerUtil'
+import { handler } from './handlerUtil';
 
-const NAMESPACE = /^[^]*[#\/]/;
-const FRAGMENT = /(?![\/#])[^\/#]*$/
+const NAMESPACE = /^[^]*[#/]/;
+const FRAGMENT = /(?![/#])[^/#]*$/;
 
 /**
  * Match the value of a NamedNode against a regular expression
  */
 function match(term, pattern) {
-  return term?.termType === 'NamedNode'
-    ? pattern.exec(term.value)?.[0]
-    : undefined;
+  return term?.termType === 'NamedNode' ?
+    pattern.exec(term.value)?.[0] :
+    undefined;
 }
 
 /**
@@ -25,12 +25,12 @@ export const fragmentHandler = handler(({ subject }) => match(subject, FRAGMENT)
 /**
  * Gets the prefix of a NamedNode subject
  */
-export const prefixHandler = handler(async (data) => {
+export const prefixHandler = handler(async data => {
   const context = await data.settings.parsedContext;
   const ns = namespaceHandler.handle(data);
   for (const key in context) {
-    if (typeof key === 'string' && context[key] === ns) {
+    if (typeof key === 'string' && context[key] === ns)
       return key;
-    }
   }
-})
+  return undefined;
+});

--- a/src/URIHandler.js
+++ b/src/URIHandler.js
@@ -1,26 +1,25 @@
 import { handler } from './handlerUtil';
 
-const NAMESPACE = /^[^#]*[#/]/;
-const FRAGMENT = /(?![/#])[^/#]*$/;
-
 /**
- * Match the value of a NamedNode against a regular expression
+ * Finds the index at which the break between the namespace and the
+ * occurs - then execute a callback with this index as the second arg
  */
-function match(term, pattern) {
-  return term?.termType === 'NamedNode' ?
-    pattern.exec(term.value)?.[0] :
-    undefined;
+function breakIndex(term, cb) {
+  if (term?.termType !== 'NamedNode') return undefined;
+  // Find the index of the last '#' or '/' if no '#' exists
+  const hashIndex = term.value.lastIndexOf('#');
+  return cb(term.value, hashIndex === -1 ? term.value.lastIndexOf('/') : hashIndex);
 }
 
 /**
  * Gets the namespace of a NamedNode subject
  */
-export const namespaceHandler = handler(({ subject }) => match(subject, NAMESPACE));
+export const namespaceHandler = handler(({ subject }) => breakIndex(subject, (str, index) => str.slice(0, index + 1)));
 
 /**
  * Gets the fragment of a NamedNode subject
  */
-export const fragmentHandler = handler(({ subject }) => match(subject, FRAGMENT));
+export const fragmentHandler = handler(({ subject }) => breakIndex(subject, (str, index) => str.slice(index + 1)));
 
 /**
  * Gets the prefix of a NamedNode subject

--- a/src/URIHandler.js
+++ b/src/URIHandler.js
@@ -1,6 +1,6 @@
 import { handler } from './handlerUtil';
 
-const NAMESPACE = /^[^]*[#/]/;
+const NAMESPACE = /^[^#]*[#/]/;
 const FRAGMENT = /(?![/#])[^/#]*$/;
 
 /**

--- a/src/defaultHandlers.js
+++ b/src/defaultHandlers.js
@@ -22,6 +22,7 @@ import ThenHandler from './ThenHandler';
 import ToArrayHandler from './ToArrayHandler';
 import { termToPrimitive } from './valueUtils';
 import { handler } from './handlerUtil';
+import { prefixHandler, namespaceHandler, fragmentHandler } from './URIHandler';
 
 /**
  * A map with default property handlers.
@@ -71,6 +72,11 @@ export default {
   toString:    DataHandler.syncFunction('subject', 'value'),
   valueOf:     subjectToPrimitiveHandler(),
   toPrimitive: subjectToPrimitiveHandler(),
+
+  // URI / namedNode handling
+  prefix: prefixHandler,
+  namespace: namespaceHandler,
+  fragment: fragmentHandler,
 
   // Add iteration helpers
   toArray: new ToArrayHandler(),

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ import defaultHandlers from './defaultHandlers';
 import { getFirstItem, iteratorFor } from './iterableUtils';
 import { lazyThenable, getThen, toIterablePromise } from './promiseUtils';
 import { isPlainObject, hasPlainObjectArgs, valueToTerm, termToPrimitive } from './valueUtils';
+import { prefixHandler, namespaceHandler, fragmentHandler } from './URIHandler';
 
 export {
   AsyncIteratorHandler,
@@ -62,4 +63,7 @@ export {
   hasPlainObjectArgs,
   valueToTerm,
   termToPrimitive,
+  prefixHandler,
+  namespaceHandler,
+  fragmentHandler
 };

--- a/src/index.js
+++ b/src/index.js
@@ -65,5 +65,5 @@ export {
   termToPrimitive,
   prefixHandler,
   namespaceHandler,
-  fragmentHandler
+  fragmentHandler,
 };

--- a/test/integration/uri-methods-test.js
+++ b/test/integration/uri-methods-test.js
@@ -1,0 +1,71 @@
+import ComunicaEngine from '@ldflex/comunica';
+import { namedNode } from '@rdfjs/data-model';
+import ComplexPathResolver from '../../src/ComplexPathResolver';
+import ContextProvider from '../../src/ContextProvider';
+import DataHandler from '../../src/DataHandler';
+import JSONLDResolver from '../../src/JSONLDResolver';
+import PathFactory from '../../src/PathFactory';
+import ThenHandler from '../../src/ThenHandler';
+import { fragmentHandler, namespaceHandler, prefixHandler } from '../../src/URIHandler';
+import context from '../context';
+
+const FOAF = 'http://xmlns.com/foaf/0.1/';
+
+describe('a query path with a path expression handler', () => {
+  const handlers = {
+    then: new ThenHandler(),
+    [Symbol.asyncIterator]: {
+      handle() {
+        const iterable = (async function* () {
+          yield namedNode('http://ex.org/#1');
+          yield namedNode('http://ex.org/#2');
+        }());
+        return () => iterable[Symbol.asyncIterator]();
+      },
+    },
+    value: DataHandler.sync('subject', 'value'),
+    termType: DataHandler.sync('subject', 'termType'),
+    prefix: prefixHandler,
+    fragment: fragmentHandler,
+    namespace: namespaceHandler
+  };
+  const contextProvider = new ContextProvider(context);
+  const resolvers = [
+    new ComplexPathResolver(contextProvider),
+    new JSONLDResolver(contextProvider),
+  ];
+  const subject = namedNode('https://example.org/#me');
+  const foafPerson = namedNode(`${FOAF}Person`);
+
+  let person;
+  let personType;
+  let noSubject;
+  beforeAll(() => {
+    const pathProxy = new PathFactory({ context, queryEngine: new ComunicaEngine(), handlers, resolvers });
+    person = pathProxy.create({ subject });
+    personType = pathProxy.create({ subject: foafPerson });
+    noSubject = pathProxy.create({});
+  });
+
+  it(`works with ${FOAF}Person and prefix in context`, async () => {
+    expect(personType.namespace).toEqual(FOAF);
+    expect(personType.fragment).toEqual('Person');
+    expect(await personType.prefix).toEqual('foaf');
+  });
+
+  it('works with https://example.org/#me & prefix not in context', async () => {
+    expect(person.namespace).toEqual('https://example.org/#');
+    expect(person.fragment).toEqual('me');
+    expect(await person.prefix).toEqual(undefined);
+  });
+
+  it('works with no subject', async () => {
+    expect(noSubject.namespace).toEqual(undefined);
+    expect(noSubject.fragment).toEqual(undefined);
+    expect(await noSubject.prefix).toEqual(undefined);
+  });
+});
+
+
+
+

--- a/test/integration/uri-methods-test.js
+++ b/test/integration/uri-methods-test.js
@@ -27,7 +27,7 @@ describe('a query path with a path expression handler', () => {
     termType: DataHandler.sync('subject', 'termType'),
     prefix: prefixHandler,
     fragment: fragmentHandler,
-    namespace: namespaceHandler
+    namespace: namespaceHandler,
   };
   const contextProvider = new ContextProvider(context);
   const resolvers = [
@@ -65,7 +65,3 @@ describe('a query path with a path expression handler', () => {
     expect(await noSubject.prefix).toEqual(undefined);
   });
 });
-
-
-
-

--- a/test/unit/URIHandler-test.js
+++ b/test/unit/URIHandler-test.js
@@ -1,5 +1,5 @@
 import { fragmentHandler, namespaceHandler } from '../../src/URIHandler';
-import { blankNode, namedNode } from '@rdfjs/data-model'
+import { blankNode, namedNode } from '@rdfjs/data-model';
 
 describe('Testing namespace handler', () => {
   it('returns the namespace of a NamedNode subject', () => {
@@ -13,7 +13,7 @@ describe('Testing namespace handler', () => {
   it('Returns correct namespace for http://example.org#jesse/wright', () => {
     expect(namespaceHandler.handle({ subject: namedNode('http://example.org#jesse/wright') })).toBe('http://example.org#');
   });
-})
+});
 
 describe('Testing fragment handler', () => {
   it('returns the namespace of a NamedNode subject', () => {
@@ -27,5 +27,5 @@ describe('Testing fragment handler', () => {
   it('Returns correct namespace for http://example.org#jesse/wright', () => {
     expect(fragmentHandler.handle({ subject: namedNode('http://example.org#jesse/wright') })).toBe('jesse/wright');
   });
-})
+});
 

--- a/test/unit/URIHandler-test.js
+++ b/test/unit/URIHandler-test.js
@@ -1,0 +1,31 @@
+import { fragmentHandler, namespaceHandler } from '../../src/URIHandler';
+import { blankNode, namedNode } from '@rdfjs/data-model'
+
+describe('Testing namespace handler', () => {
+  it('returns the namespace of a NamedNode subject', () => {
+    expect(namespaceHandler.handle({ subject: namedNode('http://example.org/subject') })).toBe('http://example.org/');
+  });
+
+  it('returns undefined on a BlankNode subject', () => {
+    expect(namespaceHandler.handle({ subject: blankNode('http://example.org/subject') })).toBe(undefined);
+  });
+
+  it('Returns correct namespace for http://example.org#jesse/wright', () => {
+    expect(namespaceHandler.handle({ subject: namedNode('http://example.org#jesse/wright') })).toBe('http://example.org#');
+  });
+})
+
+describe('Testing fragment handler', () => {
+  it('returns the namespace of a NamedNode subject', () => {
+    expect(fragmentHandler.handle({ subject: namedNode('http://example.org/subject') })).toBe('subject');
+  });
+
+  it('returns undefined on a BlankNode subject', () => {
+    expect(fragmentHandler.handle({ subject: blankNode('http://example.org/subject') })).toBe(undefined);
+  });
+
+  it('Returns correct namespace for http://example.org#jesse/wright', () => {
+    expect(fragmentHandler.handle({ subject: namedNode('http://example.org#jesse/wright') })).toBe('jesse/wright');
+  });
+})
+


### PR DESCRIPTION
Closes #73 .

Adds `.prefix`, `.namespace` and `.fragment` handlers, which have the following behavior on a subject that is a NamedNode (the handlers return `undefined` on other termTypes)

```js
ruben.namespace // 'https://ruben.verborgh.org/profile/#'
ruben.fragment // 'me'
await ruben.prefix // 'rbn'
```

I'm proposing this addition now as it is of use in a project that I am working on - but won't be offended if you do not think it is appropriate to add it here.