### PR TITLE
Clean i18n

### DIFF
--- a/src/AbstractPathResolver.js
+++ b/src/AbstractPathResolver.js
@@ -17,13 +17,7 @@ export default class AbstractPathResolver {
   async extendContext(...contexts) {
     if (contexts.length) {
       const defaultLanguages = contexts.map(context => context?.['@context']?.['@language']).filter(Boolean);
-
-      if (defaultLanguages.length) {
-        if (!this.defaultLanguage)
-          this.defaultLanguage = defaultLanguages.pop();
-        if (defaultLanguages.some(language => language !== this.defaultLanguage))
-          throw new Error('Multiple default languages given');
-      }
+      this.defaultLanguage = defaultLanguages.pop();
     }
     await this._contextProvider.extendContext(...contexts);
   }

--- a/src/AbstractPathResolver.js
+++ b/src/AbstractPathResolver.js
@@ -15,6 +15,14 @@ export default class AbstractPathResolver {
   }
 
   async extendContext(...contexts) {
+    if (contexts.length) {
+      const defaultLanguages = contexts.map(context => context && context['@context'] && context['@context']['@language']).filter(Boolean);
+      if (defaultLanguages.length) {
+        this.defaultLanguage = defaultLanguages.pop();
+        if (defaultLanguages && defaultLanguages.some(language => language !== this.defaultLanguage))
+          throw new Error('Multiple default languages given');
+      }
+    }
     await this._contextProvider.extendContext(...contexts);
   }
 
@@ -50,7 +58,7 @@ export default class AbstractPathResolver {
     const reverse = lazyThenable(() => this._context.then(({ contextRaw }) =>
       contextRaw[property] && contextRaw[property]['@reverse']));
     const resultsCache = this.getResultsCache(pathData, predicate, reverse);
-    const newData = { property, predicate, resultsCache, reverse, apply: this.apply };
+    const newData = { property, predicate, resultsCache, reverse, apply: this.apply, defaultLanguage: this.defaultLanguage };
     return pathData.extendPath(newData);
   }
 

--- a/src/AbstractPathResolver.js
+++ b/src/AbstractPathResolver.js
@@ -16,10 +16,12 @@ export default class AbstractPathResolver {
 
   async extendContext(...contexts) {
     if (contexts.length) {
-      const defaultLanguages = contexts.map(context => context && context['@context'] && context['@context']['@language']).filter(Boolean);
+      const defaultLanguages = contexts.map(context => context?.['@context']?.['@language']).filter(Boolean);
+
       if (defaultLanguages.length) {
-        this.defaultLanguage = defaultLanguages.pop();
-        if (defaultLanguages && defaultLanguages.some(language => language !== this.defaultLanguage))
+        if (!this.defaultLanguage)
+          this.defaultLanguage = defaultLanguages.pop();
+        if (defaultLanguages.some(language => language !== this.defaultLanguage))
           throw new Error('Multiple default languages given');
       }
     }

--- a/src/LanguageHandler.js
+++ b/src/LanguageHandler.js
@@ -63,6 +63,7 @@ export default class LanguageHandler {
   }
 
   async* _handle(pathData, path) {
+    pathData.skipDefaultLanguageFilter = true;
     for await (const item of path.results) {
       if (langMatches(await item.language, this.langCode))
         yield item;

--- a/src/LanguageHandler.js
+++ b/src/LanguageHandler.js
@@ -1,5 +1,49 @@
 import { toIterablePromise } from './promiseUtils';
 
+function _isWildCard(tag) {
+  return tag === '*';
+}
+
+function _matchLangTag(left, right) {
+  const matchInitial = new RegExp(`/${left}/`, 'iu');
+  return matchInitial.test(`/${right}/`);
+}
+
+// TODO: Not an XPath function
+// TODO: Publish as package
+// https://www.ietf.org/rfc/rfc4647.txt
+// https://www.w3.org/TR/sparql11-query/#func-langMatches
+export function langMatches(tag, range) {
+  const langTags = tag.split('-');
+  const rangeTags = range.split('-');
+
+  if (!_matchLangTag(rangeTags[0], langTags[0]) &&
+    !_isWildCard(langTags[0]))
+    return false;
+
+  let lI = 1;
+  let rI = 1;
+  while (rI < rangeTags.length) {
+    if (_isWildCard(rangeTags[rI])) {
+      rI++;
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+    if (lI === langTags.length)
+      return false;
+    if (_matchLangTag(rangeTags[rI], langTags[lI])) {
+      lI++;
+      rI++;
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+    if (langTags[lI].length === 1)
+      return false;
+    lI++;
+  }
+  return true;
+}
+
 /**
  * Resolves to the given item in the path data.
  * For example, new DataHandler({}, 'foo', 'bar')
@@ -20,7 +64,7 @@ export default class LanguageHandler {
 
   async* _handle(pathData, path) {
     for await (const item of path.results) {
-      if (await item.language === this.langCode)
+      if (langMatches(await item.language, this.langCode))
         yield item;
     }
   }

--- a/src/LanguageHandler.js
+++ b/src/LanguageHandler.js
@@ -1,0 +1,27 @@
+import { toIterablePromise } from './promiseUtils';
+
+/**
+ * Resolves to the given item in the path data.
+ * For example, new DataHandler({}, 'foo', 'bar')
+ * will return pathData.foo.bar.
+ *
+ * Resolution can optionally be async,
+ * and/or be behind a function call.
+ */
+export default class LanguageHandler {
+  constructor(langCode) {
+    this.langCode = langCode;
+  }
+
+  // Resolves the data path, or returns a function that does so
+  handle(pathData, path) {
+    return toIterablePromise(this._handle(pathData, path));
+  }
+
+  async* _handle(pathData, path) {
+    for await (const item of path.results) {
+      if (await item.language === this.langCode)
+        yield item;
+    }
+  }
+}

--- a/src/LanguageResolver.js
+++ b/src/LanguageResolver.js
@@ -1,0 +1,25 @@
+import JSONLDResolver from './JSONLDResolver';
+
+const isBCP47 = new RegExp(/^((?<grandfathered>(en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang))|((?<language>([A-Za-z]{2,3}(-(?<extlang>[A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-(?<script>[A-Za-z]{4}))?(-(?<region>[A-Za-z]{2}|[0-9]{3}))?(-(?<variant>[A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-(?<extension>[0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(?<privateUse>x(-[A-Za-z0-9]{1,8})+))?)|(?<privateUse1>x(-[A-Za-z0-9]{1,8})+))$/);
+
+/**
+ * Returns a new path starting from the predicate of the current path.
+ *
+ * Requires:
+ * - (optional) a predicate property on the path data
+ */
+export default class LanguageResolver extends JSONLDResolver {
+  supports(property) {
+    return typeof property === 'string' && property.startsWith('@') && isBCP47.test(property.substring(1));
+  }
+
+  /**
+   * When resolving a JSON-LD property,
+   * we create a new chainable path segment corresponding to the language.
+   *
+   * Example usage: tomato.label['@en']
+   */
+  resolve(property, pathData) {
+    return pathData.extendPath({ finalClause: queryVar => `FILTER( langMatches(${queryVar}, "${property.substring(1)}") )` });
+  }
+}

--- a/src/SparqlHandler.js
+++ b/src/SparqlHandler.js
@@ -38,6 +38,11 @@ export default class SparqlHandler {
       queryVar = this.createVar(pathData.property);
       ({ queryVar, sorts, clauses } = this.expressionToTriplePatterns(pathExpression, queryVar));
     }
+    if (pathData.defaultLanguage) {
+      queryVar = this.createVar(pathData.property);
+      clauses.push(`FILTER( langMatches(${queryVar}, "${pathData.defaultLanguage}") )`);
+    }
+
     if (pathData.finalClause)
       clauses.push(pathData.finalClause(queryVar));
 

--- a/src/SparqlHandler.js
+++ b/src/SparqlHandler.js
@@ -38,7 +38,8 @@ export default class SparqlHandler {
       queryVar = this.createVar(pathData.property);
       ({ queryVar, sorts, clauses } = this.expressionToTriplePatterns(pathExpression, queryVar));
     }
-    if (pathData.defaultLanguage) {
+
+    if (pathData.defaultLanguage && !pathData.skipDefaultLanguageFilter) {
       queryVar = this.createVar(pathData.property);
       clauses.push(`FILTER( langMatches(${queryVar}, "${pathData.defaultLanguage}") )`);
     }

--- a/test/integration/execute-query-multilingual-test.js
+++ b/test/integration/execute-query-multilingual-test.js
@@ -4,26 +4,27 @@ import LanguageResolver from '../../src/LanguageResolver';
 import { createQueryEngine } from '../util';
 import { namedNode, literal } from '@rdfjs/data-model';
 import defaultHandlers from '../../src/defaultHandlers';
+import LanguageHandler from '../../src/LanguageHandler';
 
 import context from '../context';
-
-context['@context']['@language'] = 'de';
 
 const subject = namedNode('https://example.org/#me');
 const queryEngine = createQueryEngine([
   literal('Tomato', 'en'),
+  literal('Second Tomato', 'en'),
   literal('Tomaat', 'nl'),
   literal('Tomate', 'de'),
+  literal('zweite Tomate', 'de'),
 ]);
 
-const resolvers = [
-  new LanguageResolver(context),
-  new JSONLDResolver(context),
-];
-
-describe('a query path with languages', () => {
+describe('querying a language with @langcode', () => {
   let tomato;
   beforeAll(() => {
+    const resolvers = [
+      new LanguageResolver(context),
+      new JSONLDResolver(context),
+    ];
+
     const pathProxy = new PathProxy({ handlers: defaultHandlers, resolvers });
     tomato = pathProxy.createPath({ queryEngine }, { subject });
   });
@@ -31,10 +32,87 @@ describe('a query path with languages', () => {
   it('returns results in the selected language', async () => {
     const dutchLabel = await tomato.label['@nl'];
     expect(`${dutchLabel}`).toEqual('Tomaat');
+
+    const englishLabel = await tomato.label['@en'];
+    expect(`${englishLabel}`).toEqual('Tomato');
+
+    const germanLabel = await tomato.label['@de'];
+    expect(`${germanLabel}`).toEqual('Tomate');
+  });
+});
+
+describe('querying a language with the language handler', () => {
+  let tomato;
+  beforeAll(() => {
+    const resolvers = [
+      new LanguageResolver(context),
+      new JSONLDResolver(context),
+    ];
+
+    const pathProxy = new PathProxy({ handlers: { ...defaultHandlers,
+      en: new LanguageHandler('en'),
+      de: new LanguageHandler('de'),
+      nl: new LanguageHandler('nl'),
+    }, resolvers });
+    tomato = pathProxy.createPath({ queryEngine }, { subject });
+  });
+
+  it('returns results in the selected language via the language handler', async () => {
+    const dutchLabel = await tomato.label.nl;
+    expect(`${dutchLabel}`).toEqual('Tomaat');
+
+    const englishLabel = await tomato.label.en;
+    expect(`${englishLabel}`).toEqual('Tomato');
+
+    const germanLabel = await tomato.label.de;
+    expect(`${germanLabel}`).toEqual('Tomate');
+  });
+});
+
+describe('language defaults', () => {
+  let tomato;
+  beforeAll(() => {
+    context['@context']['@language'] = 'de';
+
+    const resolvers = [
+      new LanguageResolver(context),
+      new JSONLDResolver(context),
+    ];
+
+    const pathProxy = new PathProxy({ handlers: { ...defaultHandlers,
+      en: new LanguageHandler('en'),
+      de: new LanguageHandler('de'),
+      nl: new LanguageHandler('nl'),
+    }, resolvers });
+    tomato = pathProxy.createPath({ queryEngine }, { subject });
   });
 
   it('returns results in the current language from the context', async () => {
     const germanLabel = await tomato.label;
     expect(`${germanLabel}`).toEqual('Tomate');
   });
+
+  it('returns an async iterator', async () => {
+    let counter = 0;
+
+    const results = ['Tomate', 'zweite Tomate'];
+
+    for await (const item of tomato.label.de) {
+      expect(item.toString()).toEqual(results[counter]);
+      counter++;
+    }
+  });
+
+
+  it('returns results an async iterator for a default value', async () => {
+    let counter = 0;
+
+    const results = ['Tomate', 'zweite Tomate'];
+
+    for await (const item of tomato.label) {
+      expect(item.toString()).toEqual(results[counter]);
+      counter++;
+    }
+  });
 });
+

--- a/test/integration/execute-query-multilingual-test.js
+++ b/test/integration/execute-query-multilingual-test.js
@@ -7,6 +7,8 @@ import defaultHandlers from '../../src/defaultHandlers';
 
 import context from '../context';
 
+context['@context']['@language'] = 'de';
+
 const subject = namedNode('https://example.org/#me');
 const queryEngine = createQueryEngine([
   literal('Tomato', 'en'),
@@ -26,8 +28,13 @@ describe('a query path with languages', () => {
     tomato = pathProxy.createPath({ queryEngine }, { subject });
   });
 
-  it('returns results in the current language', async () => {
+  it('returns results in the selected language', async () => {
     const dutchLabel = await tomato.label['@nl'];
     expect(`${dutchLabel}`).toEqual('Tomaat');
+  });
+
+  it('returns results in the current language from the context', async () => {
+    const germanLabel = await tomato.label;
+    expect(`${germanLabel}`).toEqual('Tomate');
   });
 });

--- a/test/integration/execute-query-multilingual-test.js
+++ b/test/integration/execute-query-multilingual-test.js
@@ -103,6 +103,16 @@ describe('language defaults', () => {
     }
   });
 
+  it('returns results in the selected language via the language handler also when a default is set', async () => {
+    const dutchLabel = await tomato.label.nl;
+    expect(`${dutchLabel}`).toEqual('Tomaat');
+
+    const englishLabel = await tomato.label.en;
+    expect(`${englishLabel}`).toEqual('Tomato');
+
+    const germanLabel = await tomato.label.de;
+    expect(`${germanLabel}`).toEqual('Tomate');
+  });
 
   it('returns results an async iterator for a default value', async () => {
     let counter = 0;

--- a/test/integration/execute-query-multilingual-test.js
+++ b/test/integration/execute-query-multilingual-test.js
@@ -1,0 +1,33 @@
+import PathProxy from '../../src/PathProxy';
+import JSONLDResolver from '../../src/JSONLDResolver';
+import LanguageResolver from '../../src/LanguageResolver';
+import { createQueryEngine } from '../util';
+import { namedNode, literal } from '@rdfjs/data-model';
+import defaultHandlers from '../../src/defaultHandlers';
+
+import context from '../context';
+
+const subject = namedNode('https://example.org/#me');
+const queryEngine = createQueryEngine([
+  literal('Tomato', 'en'),
+  literal('Tomaat', 'nl'),
+  literal('Tomate', 'de'),
+]);
+
+const resolvers = [
+  new LanguageResolver(context),
+  new JSONLDResolver(context),
+];
+
+describe('a query path with languages', () => {
+  let tomato;
+  beforeAll(() => {
+    const pathProxy = new PathProxy({ handlers: defaultHandlers, resolvers });
+    tomato = pathProxy.createPath({ queryEngine }, { subject });
+  });
+
+  it('returns results in the current language', async () => {
+    const dutchLabel = await tomato.label['@nl'];
+    expect(`${dutchLabel}`).toEqual('Tomaat');
+  });
+});

--- a/test/unit/LanguageHandler-test.js
+++ b/test/unit/LanguageHandler-test.js
@@ -1,0 +1,23 @@
+import { langMatches } from '../../src/LanguageHandler';
+
+// TODO: Add errors for when non BCP47 strings are passed
+describe('langMatches', () => {
+  const tests = [
+    [['de-DE', 'de-*-DE'], true],
+    [['de-de', 'de-*-DE'], true],
+    [['de-Latn-DE', 'de-*-DE'], true],
+    [['de-Latf-DE', 'de-*-DE'], true],
+    [['de-DE-x-goethe', 'de-*-DE'], true],
+    [['de-Latn-DE-1996', 'de-*-DE'], true],
+    [['de', 'de-*-DE'], false],
+    [['de-X-De', 'de-*-DE'], false],
+    [['de-Deva', 'de-*-DE'], false],
+  ];
+
+  it('runs all the langMatches tests correctly', () => {
+    for (const [[tag, range], isValid] of tests)
+      expect(langMatches(tag, range)).toBe(isValid);
+  });
+});
+
+

--- a/test/util.js
+++ b/test/util.js
@@ -16,9 +16,12 @@ export function createQueryEngine(variableNames, results) {
 
       if (matches && matches.length && matches[1]) {
         const language = matches[2];
-        const languageResult = results.filter(result => result.language === language);
-        const bindings = variableNames.map((name, i) => [name, languageResult[i]]);
-        yield new Map(bindings);
+        const languageResults = results
+          .filter(languageResult => languageResult.language === language)
+          .map(languageResult => [['?value', languageResult]]);
+
+        for (const languageResult of languageResults)
+          yield new Map(languageResult);
       }
       else {
         for (let result of results) {

--- a/test/util.js
+++ b/test/util.js
@@ -11,11 +11,11 @@ export function createQueryEngine(variableNames, results) {
   }
   return {
     execute: jest.fn(async function*(query) {
-      const regex = new RegExp('langMatches\\(\\?result, "([a-z]*)');
+      const regex = new RegExp('langMatches\\(\\?([a-z]*), "([a-z]*)');
       const matches = query.match(regex);
 
       if (matches && matches.length && matches[1]) {
-        const language = matches[1];
+        const language = matches[2];
         const languageResult = results.filter(result => result.language === language);
         const bindings = variableNames.map((name, i) => [name, languageResult[i]]);
         yield new Map(bindings);

--- a/test/util.js
+++ b/test/util.js
@@ -10,12 +10,23 @@ export function createQueryEngine(variableNames, results) {
     variableNames = ['?value'];
   }
   return {
-    execute: jest.fn(async function*() {
-      for (let result of results) {
-        if (!Array.isArray(result))
-          result = [result];
-        const bindings = variableNames.map((name, i) => [name, result[i]]);
+    execute: jest.fn(async function*(query) {
+      const regex = new RegExp('langMatches\\(\\?result, "([a-z]*)');
+      const matches = query.match(regex);
+
+      if (matches && matches.length && matches[1]) {
+        const language = matches[1];
+        const languageResult = results.filter(result => result.language === language);
+        const bindings = variableNames.map((name, i) => [name, languageResult[i]]);
         yield new Map(bindings);
+      }
+      else {
+        for (let result of results) {
+          if (!Array.isArray(result))
+            result = [result];
+          const bindings = variableNames.map((name, i) => [name, result[i]]);
+          yield new Map(bindings);
+        }
       }
     }),
   };


### PR DESCRIPTION
Start of adding support for languages.

I closed the previous try: https://github.com/LDflex/LDflex/pull/69.

This PR adds support for:

```
await tomato.label['@nl'] // Tomaat
```
```
const context = {
  '@language': 'de'
}
await tomato.label // Tomate

```

